### PR TITLE
Added Qt 5 support, native Mac toolbar

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,45 @@
+2016-12-24  JMB  Added Qt 5 support, native Mac toolbar
+
+    Added support for Qt 5 to get the latest fixes for actively supported
+    platforms and enable ports to new ones, without yet dropping Qt 4
+    support (needed for Maemo devices).
+
+    Used and extended QMacToolBar to get a native toolbar on Mac OS X,
+    complete with the usual customization options.
+
+2015-10-11  JMB  Automated Fremantle builds, fixed cppcheck findings
+
+    Added the packaging/maemo/fremantle_vm.sh script to automate Maemo
+    Fremantle builds, similar to the one already done for Diablo.
+
+    Automated execution of the "cppcheck" static code analysis utility and
+    fixed the potential issues it reported.
+
+2015-10-04  JMB  Added Maemo Diablo build script using VM
+
+    Added the packaging/maemo/diablo_vm.sh script to fully automate builds
+    of the Maemo Diablo version of PortaBase, launching and closing the
+    development virtual machine as necessary.
+
+2015-07-27  JMB  Fixed bugs in handling of new src dir
+
+    Fixed a few bugs in the updated copy_source.sh script.
+
+2015-07-19  JMB  Moved source code under src directory
+
+    From the early days when PortaBase was a much smaller program, the main
+    source code files have always been in the project root directory. This is
+    no longer appropriate now that the number of files has grown and the
+    repository is being hosted on GitHub where this structure is burying the
+    README well down the page. Created a "src" directory, moved the source
+    files into it, and updated all scripts to cope with the new
+    organizational structure.
+
+2015-07-07  JMB  Replaced usage of deprecated date-setting method
+
+    Replace usage of the deprecated QDate.setYMD() with setDate() in order to
+    prepare for Qt 5 support.
+
 2013-10-06  JMB  More CSV import/export options from command line
 
     Added several improvements to the import and export of CSV files from the

--- a/doc/install_mac.txt
+++ b/doc/install_mac.txt
@@ -2,11 +2,9 @@ Mac OS X Development Environment
 --------------------------------
 To compile PortaBase for use as a Mac OS X desktop application, you will
 need the following:
-- Mac OS X Tiger (10.4) or higher; Leopard (10.5) or higher for Cocoa and/or
-  64-bit support
-- Xcode (if running Xcode 4, be sure to install the command line utilities
-  from Preferences -> Downloads)
-- A recent version of Qt (https://www.qt.io/download/); 4.8 or higher is
+- Mac OS X Snow Leopard (10.6) or higher
+- Xcode (be sure to also install the command line utilities)
+- A recent version of Qt (https://www.qt.io/download/); 5.5 or higher is
   recommended.
 
 Metakit Compilation
@@ -20,11 +18,7 @@ autobuilders).
 To compile Metakit for Mac OS X, from the root PortaBase source directory run
 "packaging/mac/build_metakit.sh"; it'll prompt you for your password near the
 end in order to install the files under /usr/local where they will be found
-later when compiling PortaBase.  Note that this script is configured assuming
-that you're on Leopard or later, compiling only for Intel 64-bit processors;
-supporting Tiger, PowerPC processors, or 32-bit Intel processors requires some
-additional effort (especially if you're using Xcode 4 instead of an earlier
-version).
+later when compiling PortaBase.
 
 Help Pages Generation
 ---------------------

--- a/packaging/mac/build.sh
+++ b/packaging/mac/build.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
+#
+# (c) 2010-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 
 # Script for packaging the Mac version of PortaBase for distribution
 # Assumes that we are in the PortaBase source code root directory
 # Takes the parameter to make -j as an argument, for utilizing multiple cores
 
-# By default, builds a 64-bit Intel binary.  If you want to build a universal
-# binary that runs on PowerPC and 32-bit Intel Macs, pass the string
-# "--universal" as the first parameter.  You'll need to have a suitably old or
-# hacked version of Xcode, and appropriately compiled versions of Qt and
-# Metakit.
+# This script builds a 64-bit Intel binary; support for PowerPC and 32-bit
+# Intel Macs was dropped with the upgrade to Qt 5
 
 VERSION=`cat packaging/version_number`
 DIRNAME=PortaBase_$VERSION
@@ -20,14 +24,7 @@ rm -rf build/$DIRNAME
 rm -rf resources/help/_build/_static # in case created for Maemo
 
 # compile and make the application bundle
-if [ "$1" == "--universal" ]; then
-    shift 1
-    qmake -spec macx-g++40 portabase.pro
-    UNIVERSAL=Yes
-else
-    qmake -spec macx-llvm portabase.pro
-    UNIVERSAL=No
-fi
+qmake -spec macx-llvm portabase.pro
 if [ "$1" == "--sign" ]; then
     SIGN=Yes
     shift 1
@@ -109,11 +106,7 @@ mv PortaBase.app $DIRNAME
 cp ../README.txt $DIRNAME/ReadMe
 cp ../CHANGES $DIRNAME/Changes
 cp ../COPYING $DIRNAME/License
-if [ "$UNIVERSAL" == "Yes" ]; then
-    DMGNAME=${DIRNAME}_universal.dmg
-else
-    DMGNAME=$DIRNAME.dmg
-fi
+DMGNAME=$DIRNAME.dmg
 hdiutil create $DMGNAME -srcfolder $DIRNAME -format UDZO -volname $DIRNAME
 if [ "$SIGN" == "Yes" ]; then
     codesign -s "Developer ID Application: Jeremy Bowman" $DMGNAME

--- a/portabase.pro
+++ b/portabase.pro
@@ -2,6 +2,7 @@ TEMPLATE        = app
 CONFIG         += qt warn_on thread
 #DEFINES        += TRACE_ENABLED # enables TRACE macro for crash debugging
 QT             += xml
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets printsupport
 DESTDIR         = build
 OBJECTS_DIR     = build
 MOC_DIR         = build
@@ -77,6 +78,7 @@ HEADERS         = src/calc/calcdateeditor.h \
                   src/qqutil/qqdialog.h \
                   src/qqutil/qqmainwindow.h \
                   src/qqutil/qqmenuhelper.h \
+                  src/qqutil/qqtoolbar.h \
                   src/qqutil/qqtoolbarstretch.h \
                   src/roweditor.h \
                   src/rowviewer.h \
@@ -147,6 +149,7 @@ SOURCES         = src/calc/calcdateeditor.cpp \
                   src/qqutil/qqdialog.cpp \
                   src/qqutil/qqmainwindow.cpp \
                   src/qqutil/qqmenuhelper.cpp \
+                  src/qqutil/qqtoolbar.cpp \
                   src/qqutil/qqtoolbarstretch.cpp \
                   src/roweditor.cpp \
                   src/rowviewer.cpp \
@@ -168,9 +171,17 @@ unix {
 
 # Stuff for Mac OS X
 macx {
-    macx-g++40:CONFIG  += release x86 ppc
-    !macx-g++40:CONFIG += release x86_64
+    CONFIG             += c++11 release x86_64
+    QMAKE_CXXFLAGS     += -stdlib=libc++ -std=c++11
+    QMAKE_MAC_SDK       = macosx10.11
+    QT                 += macextras
+    INCLUDEPATH        += /usr/local/include
+    LIBS               += -L/usr/local/lib -framework Foundation
     TARGET              = PortaBase
+    HEADERS            += src/qqutil/qqmactoolbardelegate.h \
+                          src/qqutil/qqmactoolbarutils.h
+    OBJECTIVE_SOURCES  += src/qqutil/qqmactoolbardelegate.mm \
+                          src/qqutil/qqmactoolbarutils.mm
     RESOURCES           = resources/mac.qrc
     ICON                = packaging/mac/PortaBase.icns
     DOCUMENT_ICON.files = packaging/mac/PortaBaseFile.icns

--- a/src/color_picker/qtcolorpicker.cpp
+++ b/src/color_picker/qtcolorpicker.cpp
@@ -3,6 +3,7 @@
 ** This file is part of a Qt Solutions component.
 ** 
 ** Copyright (c) 2009 Nokia Corporation and/or its subsidiary(-ies).
+** Copyright (c) 2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
 ** 
 ** Contact:  Qt Software Information (qt-info@nokia.com)
 ** 
@@ -44,24 +45,24 @@
 ** 
 ****************************************************************************/
 
-#include <QtGui/QApplication>
-#include <QtGui/QDesktopWidget>
-#include <QtGui/QPainter>
-#include <QtGui/QPushButton>
-#include <QtGui/QColorDialog>
+#include <QApplication>
+#include <QDesktopWidget>
+#include <QPainter>
+#include <QPushButton>
+#include <QColorDialog>
 #include <QtCore/QMap>
-#include <QtGui/QLayout>
-#include <QtGui/QStyle>
-#include <QtGui/QLabel>
-#include <QtGui/QToolTip>
-#include <QtGui/QPixmap>
-#include <QtGui/QFocusEvent>
-#include <QtGui/QPaintEvent>
-#include <QtGui/QGridLayout>
-#include <QtGui/QHideEvent>
-#include <QtGui/QKeyEvent>
-#include <QtGui/QShowEvent>
-#include <QtGui/QMouseEvent>
+#include <QLayout>
+#include <QStyle>
+#include <QLabel>
+#include <QToolTip>
+#include <QPixmap>
+#include <QFocusEvent>
+#include <QPaintEvent>
+#include <QGridLayout>
+#include <QHideEvent>
+#include <QKeyEvent>
+#include <QShowEvent>
+#include <QMouseEvent>
 #include <math.h>
 
 #include "qtcolorpicker.h"

--- a/src/color_picker/qtcolorpicker.h
+++ b/src/color_picker/qtcolorpicker.h
@@ -3,6 +3,7 @@
 ** This file is part of a Qt Solutions component.
 ** 
 ** Copyright (c) 2009 Nokia Corporation and/or its subsidiary(-ies).
+** Copyright (c) 2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
 ** 
 ** Contact:  Qt Software Information (qt-info@nokia.com)
 ** 
@@ -46,15 +47,15 @@
 
 #ifndef QTCOLORPICKER_H
 #define QTCOLORPICKER_H
-#include <QtGui/QPushButton>
+#include <QPushButton>
 #include <QtCore/QString>
-#include <QtGui/QColor>
+#include <QColor>
 
-#include <QtGui/QLabel>
+#include <QLabel>
 #include <QtCore/QEvent>
-#include <QtGui/QFocusEvent>
+#include <QFocusEvent>
 
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 #  if !defined(QT_QTCOLORPICKER_EXPORT) && !defined(QT_QTCOLORPICKER_IMPORT)
 #    define QT_QTCOLORPICKER_EXPORT
 #  elif defined(QT_QTCOLORPICKER_IMPORT)

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1,7 +1,7 @@
 /*
  * database.cpp
  *
- * (c) 2002-2004,2008-2013,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2002-2004,2008-2013,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -71,7 +71,7 @@ Database::Database(const QString &path, OpenResult *result, bool encrypt)
         }
         canWrite = info.isWritable();
     }
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
     file = new c4_Storage(path.toUtf8(), canWrite);
 #else
     file = new c4_Storage(QFile::encodeName(path), canWrite);

--- a/src/datewidget.cpp
+++ b/src/datewidget.cpp
@@ -1,7 +1,7 @@
 /*
  * datewidget.cpp
  *
- * (c) 2002-2004,2008-2012 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2002-2004,2008-2012,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -108,7 +108,7 @@ void DateWidget::updateDisplay()
  */
 QString DateWidget::toString(const QDate &date)
 {
-#if defined(Q_WS_MAC)
+#if defined(Q_OS_MAC)
     QString value("%1, %2");
     value = value.arg(QDate::longDayName(date.dayOfWeek()));
     return value.arg(date.toString(Qt::DefaultLocaleLongDate));

--- a/src/encryption/blowfish.cpp
+++ b/src/encryption/blowfish.cpp
@@ -3,7 +3,7 @@
  *
  * Adapted from BeeCrypt: http://sourceforge.net/projects/beecrypt
  *
- * (c) 2008-2010 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2008-2010,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  * (c) 1999, 2000, 2002, 2005 Beeyond Software Holding BV
  *
  * This library is free software; you can redistribute it and/or
@@ -407,12 +407,12 @@ QByteArray Blowfish::decrypt(const QByteArray &data, const QByteArray &iv)
  */
 int Blowfish::blockEncryptCBC(quint32 *dst, const quint32 *src, unsigned int nblocks)
 {
-	register const unsigned int blockwords = Blowfish::blockSize >> 2;
-	register quint32 *fdback = encryptParam.fdback;
+	const unsigned int blockwords = Blowfish::blockSize >> 2;
+	quint32 *fdback = encryptParam.fdback;
 
 	if (nblocks > 0)
 	{
-		register unsigned int i;
+        unsigned int i;
 
 		for (i = 0; i < blockwords; i++)
 			dst[i] = src[i] ^ fdback[i];
@@ -453,16 +453,16 @@ int Blowfish::blockEncryptCBC(quint32 *dst, const quint32 *src, unsigned int nbl
  */
 int Blowfish::blockDecryptCBC(quint32 *dst, const quint32 *src, unsigned int nblocks)
 {
-	register const unsigned int blockwords = Blowfish::blockSize >> 2;
-	register quint32 *fdback = decryptParam.fdback;
-	register quint32 *buf = (quint32*) malloc(blockwords * sizeof(quint32));
+	const unsigned int blockwords = Blowfish::blockSize >> 2;
+	quint32 *fdback = decryptParam.fdback;
+	quint32 *buf = (quint32*) malloc(blockwords * sizeof(quint32));
 
 	if (buf)
 	{
 		while (nblocks > 0)
 		{
-			register quint32 tmp;
-			register unsigned int i;
+			quint32 tmp;
+			unsigned int i;
 
 			decrypt(&decryptParam, buf, src);
 
@@ -498,9 +498,9 @@ int Blowfish::setup(blowfishParam *bp, const quint8* key, size_t keybits)
 {
 	if (((keybits & 7) == 0) && (keybits >= 32) && (keybits <= 448))
 	{
-		register quint32* p = bp->p;
-		register quint32* s = bp->s;
-		register unsigned int i, j, k;
+		quint32* p = bp->p;
+		quint32* s = bp->s;
+		unsigned int i, j, k;
 
 		quint32 tmp, work[2];
 
@@ -584,12 +584,12 @@ int Blowfish::setIV(blowfishParam *bp, const quint8* iv)
 int Blowfish::encrypt(blowfishParam *bp, quint32* dst, const quint32* src)
 {
 	#if Q_BYTE_ORDER == Q_BIG_ENDIAN
-	register quint32 xl = src[0], xr = src[1];
+	quint32 xl = src[0], xr = src[1];
 	#else
-	register quint32 xl = swapu32(src[0]), xr = swapu32(src[1]);
+	quint32 xl = swapu32(src[0]), xr = swapu32(src[1]);
 	#endif
-	register quint32* p = bp->p;
-	register quint32* s = bp->s;
+	quint32* p = bp->p;
+	quint32* s = bp->s;
 
 	EROUND(xl, xr); EROUND(xr, xl);
 	EROUND(xl, xr); EROUND(xr, xl);
@@ -623,12 +623,12 @@ int Blowfish::encrypt(blowfishParam *bp, quint32* dst, const quint32* src)
 int Blowfish::decrypt(blowfishParam *bp, quint32* dst, const quint32* src)
 {
 	#if Q_BYTE_ORDER == Q_BIG_ENDIAN
-	register quint32 xl = src[0], xr = src[1];
+	quint32 xl = src[0], xr = src[1];
 	#else
-	register quint32 xl = swapu32(src[0]), xr = swapu32(src[1]);
+	quint32 xl = swapu32(src[0]), xr = swapu32(src[1]);
 	#endif
-	register quint32* p = bp->p+BLOWFISHPSIZE-1;
-	register quint32* s = bp->s;
+	quint32* p = bp->p+BLOWFISHPSIZE-1;
+	quint32* s = bp->s;
 
 	DROUND(xl, xr); DROUND(xr, xl);
 	DROUND(xl, xr); DROUND(xr, xl);

--- a/src/encryption/bytestream.cpp
+++ b/src/encryption/bytestream.cpp
@@ -1,7 +1,7 @@
 /*
  * bytestream.cpp
  *
- * (c) 2003,2008 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003,2008,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,8 +25,7 @@
  *
  * @param data The byte array to read from
  */
-ByteStream::ByteStream(const QByteArray &data) : content(data), location(0),
-    writing(false)
+ByteStream::ByteStream(const QByteArray &data) : content(data), location(0)
 {
 
 }
@@ -34,7 +33,7 @@ ByteStream::ByteStream(const QByteArray &data) : content(data), location(0),
 /**
  * Constructor for writing.
  */
-ByteStream::ByteStream() : location(0), writing(true)
+ByteStream::ByteStream() : location(0)
 {
 
 }

--- a/src/encryption/bytestream.h
+++ b/src/encryption/bytestream.h
@@ -1,7 +1,7 @@
 /*
  * bytestream.h
  *
- * (c) 2003,2008,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003,2008,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +39,6 @@ public:
 private:
     QByteArray content; /**< The stored byte array */
     int location; /**< The current read or write location in the content */
-    bool writing; /**< True if the content is being written to */
 };
 
 #endif

--- a/src/encryption/randomkit/rk_isaac.c
+++ b/src/encryption/randomkit/rk_isaac.c
@@ -31,9 +31,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-static char const rcsid[] =
-  "@(#) $Jeannot: rk_isaac.c,v 1.4 2006/02/20 19:13:37 js Exp $";
-
 #include "rk_isaac.h"
 #include <limits.h>
 #include <math.h>

--- a/src/encryption/randomkit/rk_mt.c
+++ b/src/encryption/randomkit/rk_mt.c
@@ -35,9 +35,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-static char const rcsid[] =
-  "@(#) $Jeannot: rk_mt.c,v 1.6 2006/02/19 13:48:34 js Exp $";
-
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -1,7 +1,7 @@
 /*
  * factory.cpp
  *
- * (c) 2008-2012 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2008-2012,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -201,11 +201,19 @@ QTreeWidget *Factory::treeWidget(QWidget *parent, const QStringList &headers)
     table->setUniformRowHeights(true);
     int colCount = headers.count();
     if (colCount > 0) {
-      table->setColumnCount(headers.count());
-      table->setHeaderLabels(headers);
-      table->header()->setResizeMode(QHeaderView::ResizeToContents);
+        table->setColumnCount(headers.count());
+        table->setHeaderLabels(headers);
+#if QT_VERSION >= 0x050000
+        table->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+#else
+        table->header()->setResizeMode(QHeaderView::ResizeToContents);
+#endif
     }
+#if QT_VERSION >= 0x050000
+    table->header()->setSectionsMovable(false);
+#else
     table->header()->setMovable(false);
+#endif
     table->setSortingEnabled(false);
     table->setAllColumnsShowFocus(true);
     table->setRootIsDecorated(false);
@@ -225,7 +233,7 @@ QTreeWidget *Factory::treeWidget(QWidget *parent, const QStringList &headers)
  */
 QAbstractButton *Factory::button(QWidget *parent)
 {
-#if defined(Q_WS_MAC)
+#if defined(Q_OS_MAC)
     return new QToolButton(parent);
 #else
     return new QPushButton(parent);

--- a/src/formatting.cpp
+++ b/src/formatting.cpp
@@ -1,7 +1,7 @@
 /*
  * formatting.cpp
  *
- * (c) 2010-2011,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2010-2011,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,6 +14,7 @@
  */
 
 #include <QSettings>
+#include <QTextDocument>
 #include <QTime>
 #include "formatting.h"
 
@@ -308,4 +309,21 @@ QString Formatting::parseTimeString(const QString &value, bool *ok)
     int totalSeconds = midnight.secsTo(time);
     *ok = true;
     return QString::number(totalSeconds);
+}
+
+/**
+ * Get a copy of the provided string with HTML/XML special characters (such as
+ * '<', '>', '&', and '"') escaped.  Abstracts away the different APIs for doing
+ * this in Qt 4 and 5.
+ *
+ * @param value The string to be escaped
+ * @return A copy of the input string with special characters escaped
+ */
+QString Formatting::toHtmlEscaped(const QString &value)
+{
+#if QT_VERSION >= 0x050000
+  return value.toHtmlEscaped();
+#else
+  return Qt::escape(value);
+#endif
 }

--- a/src/formatting.h
+++ b/src/formatting.h
@@ -1,7 +1,7 @@
 /*
  * formatting.h
  *
- * (c) 2010-2011,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2010-2011,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,6 +42,7 @@ public:
     static QString timeToString(int time);
     static QString dateTimeToString(const QDateTime &dateTime);
     static QString parseTimeString(const QString &value, bool *ok);
+    static QString toHtmlEscaped(const QString &value);
 
 private:
     static QLocale cLocale; /**< The "C" locale used internally */

--- a/src/image/imageeditor.cpp
+++ b/src/image/imageeditor.cpp
@@ -1,7 +1,7 @@
 /*
  * imageeditor.cpp
  *
- * (c) 2003-2004,2008-2010,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003-2004,2008-2010,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -112,7 +112,7 @@ int ImageEditor::edit(const QString &file)
     QPixmap pm = QPixmap::fromImage(image);
     display->setPixmap(pm);
     int margin = 5;
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
     margin += 16;
 #endif
     resize(qMax(pm.width() + margin, paramsRow->sizeHint().width() + margin),

--- a/src/menuactions.cpp
+++ b/src/menuactions.cpp
@@ -1,7 +1,7 @@
 /*
  * menuactions.cpp
  *
- * (c) 2003-2004,2009-2010 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003-2004,2009-2010,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,6 +34,7 @@ MenuActions::MenuActions(QObject *parent)
     textMap.insert(ChangePassword, tr("C&hange Password") + ellipsis);
     toolTipMap.insert(ChangePassword, tr("Change the current file's password"));
 
+    objectNameMap.insert(Import, "Import");
     textMap.insert(Import, tr("&Import") + ellipsis);
     toolTipMap.insert(Import, tr("Create a new file from data in another format"));
 
@@ -56,10 +57,12 @@ MenuActions::MenuActions(QObject *parent)
     toolTipMap.insert(Print, tr("Print the current file"));
     shortcutMap.insert(Print, QKeySequence(QKeySequence::Print));
 
+    objectNameMap.insert(QuickFilter, "Quick Filter");
     textMap.insert(QuickFilter, tr("&Quick Filter"));
     toolTipMap.insert(QuickFilter, tr("Apply a one-condition filter"));
     shortcutMap.insert(QuickFilter, QKeySequence(QKeySequence::Find));
 
+    objectNameMap.insert(AddRow, "AddRow");
     textMap.insert(AddRow, tr("&Add") + ellipsis);
     toolTipMap.insert(AddRow, tr("Create a new row"));
 
@@ -72,6 +75,7 @@ MenuActions::MenuActions(QObject *parent)
     textMap.insert(AddFilter, tr("&Add") + ellipsis);
     toolTipMap.insert(AddFilter, tr("Create a new filter"));
 
+    objectNameMap.insert(EditRow, "Edit Row");
     textMap.insert(EditRow, tr("&Edit") + ellipsis);
     toolTipMap.insert(EditRow, tr("Edit the selected row"));
 
@@ -84,6 +88,7 @@ MenuActions::MenuActions(QObject *parent)
     textMap.insert(EditFilter, tr("&Edit") + ellipsis);
     toolTipMap.insert(EditFilter, tr("Edit the selected filter"));
 
+    objectNameMap.insert(DeleteRow, "Delete Row");
     textMap.insert(DeleteRow, tr("&Delete"));
     toolTipMap.insert(DeleteRow, tr("Delete the selected row"));
     shortcutMap.insert(DeleteRow, QKeySequence::Delete);
@@ -103,6 +108,7 @@ MenuActions::MenuActions(QObject *parent)
     textMap.insert(AllRows, tr("All &Rows"));
     toolTipMap.insert(AllRows, tr("Show all rows of data"));
 
+    objectNameMap.insert(CopyRow, "Copy Row");
     textMap.insert(CopyRow, tr("&Copy") + ellipsis);
     toolTipMap.insert(CopyRow, tr("Create a copy of the selected row"));
 
@@ -122,15 +128,19 @@ MenuActions::MenuActions(QObject *parent)
     textMap.insert(EditEnums, tr("Edit E&nums") + ellipsis);
     toolTipMap.insert(EditEnums, tr("Edit the enumerated data types"));
 
+    objectNameMap.insert(Views, "Views");
     textMap.insert(Views, tr("Views") + ellipsis);
     toolTipMap.insert(Views, tr("Change the active view"));
 
+    objectNameMap.insert(Sortings, "Sortings");
     textMap.insert(Sortings, tr("Sortings") + ellipsis);
     toolTipMap.insert(Sortings, tr("Change the active sorting"));
 
+    objectNameMap.insert(Filters, "Filters");
     textMap.insert(Filters, tr("Filters") + ellipsis);
     toolTipMap.insert(Filters, tr("Change the active filter"));
 
+    objectNameMap.insert(Fullscreen, "Fullscreen");
     textMap.insert(Fullscreen, tr("Fullscreen"));
     toolTipMap.insert(Fullscreen, tr("View PortaBase in fullscreen mode"));
 }
@@ -169,7 +179,7 @@ QAction *MenuActions::action(Item item, bool toggle)
 QAction *MenuActions::action(Item item, const QIcon &icon)
 {
     QAction *action = new QAction(icon, menuText(item), parent());
-#if defined(Q_WS_MAC) || defined(Q_WS_HILDON)
+#if defined(Q_OS_MAC) || defined(Q_WS_HILDON)
     action->setIconVisibleInMenu(false);
 #endif
     prepareAction(item, action);
@@ -184,6 +194,9 @@ QAction *MenuActions::action(Item item, const QIcon &icon)
  */
 void MenuActions::prepareAction(Item item, QAction *action)
 {
+    if (objectNameMap.contains(item)) {
+        action->setObjectName(objectNameMap[item]);
+    }
     if (toolTipMap.contains(item)) {
         QString text = toolTipMap[item];
         action->setToolTip(text);

--- a/src/menuactions.h
+++ b/src/menuactions.h
@@ -1,7 +1,7 @@
 /*
  * menuactions.h
  *
- * (c) 2003,2009-2010,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003,2009-2010,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -93,6 +93,7 @@ private:
     void prepareAction(Item item, QAction *action);
 
 private:
+    PhraseMap objectNameMap; /**< Mapping of items to object names (not all items have one) */
     PhraseMap textMap; /**< Mapping of items to translations (including accelerators) */
     PhraseMap toolTipMap; /**< Mapping of items to translated tooltips */
     ShortcutMap shortcutMap; /**< Mapping of items to shortcut key combinations */

--- a/src/portabase.h
+++ b/src/portabase.h
@@ -1,7 +1,7 @@
 /*
  * portabase.h
  *
- * (c) 2002-2004,2008-2011,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2002-2004,2008-2011,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -111,8 +111,6 @@ private:
     void showFileSelector();
     void showDataViewer();
     QSettings *getSettings();
-    void createFillerActions();
-    void showAllFillerActions();
     void updatePreferences(QSettings *settings);
 
 private:
@@ -159,7 +157,6 @@ private:
     QAction *sortingsAction; /**< Toolbar "Sortings" action */
     QAction *filtersAction; /**< Toolbar "Filters" action */
     QAction *fullscreenAction; /**< Toolbar "Fullscreen" action */
-    QAction* fillerActions[6]; /**< Toolbar filler actions; Mac toolbar quirk */
     QMenu *row; /**< "Row" Menu */
     QMenu *view; /**< "View" Menu */
     QMenu *sort; /**< "Sort" Menu */

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -1,7 +1,7 @@
 /*
  * preferences.cpp
  *
- * (c) 2002-2004,2009-2012 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2002-2004,2009-2012,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -230,7 +230,7 @@ void Preferences::addAppearanceTab(QSettings *settings)
         appearanceTab = panel;
         layout = static_cast<QVBoxLayout *>(panel->layout());
     }
-#if !defined(Q_WS_MAC)
+#if !defined(Q_OS_MAC)
     QGroupBox *fontGroup = new QGroupBox(tr("Font"), appearanceTab);
     layout->addWidget(fontGroup);
     QGridLayout *fontGrid = Factory::gridLayout(fontGroup, true);
@@ -434,7 +434,7 @@ QFont Preferences::applyChanges()
     settings.endGroup();
 #endif
 
-#if !defined(Q_WS_MAC)
+#if !defined(Q_OS_MAC)
     settings.beginGroup("Font");
     QString name = fontName->currentText();
     int size = sizes[fontSize->currentIndex()];

--- a/src/qqutil/qqdialog.cpp
+++ b/src/qqutil/qqdialog.cpp
@@ -1,7 +1,7 @@
 /*
  * qqutil/qqdialog.cpp
  *
- * (c) 2003-2012 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003-2012,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,18 +62,23 @@ QQDialog::~QQDialog()
 }
 
 /**
- * Overrides QWidget::setWindowTitle() to include the application name.
+ * Overrides QWidget::setWindowTitle() to include the application name. Qt 5
+ * does this automatically when appropriate, so this is just for Maemo now.
  *
  * @param title The dialog title, not including the application name
  */
 void QQDialog::setWindowTitle(const QString &title)
 {
+#if QT_VERSION >= 0x050000
+    QWidget::setWindowTitle(title);
+#else
     if (title.isEmpty()) {
         QWidget::setWindowTitle(qApp->applicationName());
     }
     else {
         QWidget::setWindowTitle(title + " - " + qApp->applicationName());
     }
+#endif
 }
 
 /**

--- a/src/qqutil/qqmactoolbardelegate.h
+++ b/src/qqutil/qqmactoolbardelegate.h
@@ -1,0 +1,44 @@
+/*
+ * qqmactoolbaritemvalidator.h
+ *
+ * (c) 2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/** @file qqutil/qqmactoolbaritemvalidator.h
+ * Header file for QQMacToolbarItemValidator
+ */
+
+#ifndef QQMACTOOLBARDELEGATE_H
+#define QQMACTOOLBARDELEGATE_H
+
+#import <AppKit/AppKit.h>
+
+#include <QtCore/qglobal.h>
+
+class QQToolBar;
+
+/**
+ * Delegate for Mac native toolbars.  Replaces QMacToolbarDelegate in order to
+ * support disabling and re-enabling items in sync with the corresponding
+ * QActions.
+ */
+@interface QQMacToolbarDelegate : NSObject <NSToolbarDelegate>
+{
+@public
+    QQToolBar *toolBar;
+}
+
+- (NSToolbarItem *) toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSString *) itemIdent willBeInsertedIntoToolbar:(BOOL) willBeInserted;
+- (NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar*)toolbar;
+- (NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar*)toolbar;
+- (NSArray *)toolbarSelectableItemIdentifiers:(NSToolbar *)toolbar;
+- (IBAction)itemClicked:(id)sender;
+- (BOOL)validateToolbarItem:(NSToolbarItem *)toolbarItem;
+@end
+
+#endif // QQMACTOOLBARDELEGATE_H

--- a/src/qqutil/qqmactoolbardelegate.mm
+++ b/src/qqutil/qqmactoolbardelegate.mm
@@ -1,0 +1,96 @@
+/*
+ * qqmactoolbaritemvalidator.mm
+ *
+ * (c) 2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/** @file qqutil/qqmactoolbaritemvalidator.mm
+ * Source file for QQMacToolbarItemValidator
+ */
+
+#include <QtCore/QString>
+#include <QMacToolBar>
+#include <QMacToolBarItem>
+#include <qmactoolbaritem.h>
+
+#include "qmacfunctions.h"
+#include "qqmactoolbardelegate.h"
+#include "qqmactoolbarutils.h"
+#include "qqtoolbar.h"
+
+/**
+ * Get the native toolbar identifier strings for all items in the given list.
+ * @param items The items whose identifiers are to be fetched
+ * @param cullUnselectable True if unselectable items should be skipped
+ * @return An array o native toolbar item identifiers
+ */
+NSMutableArray *getItemIdentifiers(const QList<QMacToolBarItem *> &items, bool cullUnselectable)
+{
+    NSMutableArray *array = [[NSMutableArray alloc] init];
+    foreach (const QMacToolBarItem *item, items) {
+        if (cullUnselectable && item->selectable() == false)
+            continue;
+        [array addObject : [item->nativeToolBarItem() itemIdentifier]];
+    }
+    return array;
+}
+
+QT_USE_NAMESPACE
+
+@implementation QQMacToolbarDelegate
+
+- (NSArray *)toolbarDefaultItemIdentifiers:(NSToolbar*)toolbar
+{
+    Q_UNUSED(toolbar);
+    return getItemIdentifiers(toolBar->macToolBar()->items(), false);
+}
+
+- (NSArray *)toolbarAllowedItemIdentifiers:(NSToolbar*)toolbar
+{
+    Q_UNUSED(toolbar);
+    return getItemIdentifiers(toolBar->macToolBar()->allowedItems(), false);
+}
+
+- (NSArray *)toolbarSelectableItemIdentifiers: (NSToolbar *)toolbar
+{
+    Q_UNUSED(toolbar);
+    NSMutableArray *array = getItemIdentifiers(toolBar->macToolBar()->items(), true);
+    [array addObjectsFromArray:getItemIdentifiers(toolBar->macToolBar()->allowedItems(), true)];
+    return array;
+}
+
+- (IBAction)itemClicked:(id)sender
+{
+    NSToolbarItem *nativeItem = reinterpret_cast<NSToolbarItem *>(sender);
+    QString identifier = QString::fromNSString([nativeItem itemIdentifier]);
+    QMacToolBarItem *item = toolBar->itemFor(identifier);
+    emit item->activated();
+}
+
+- (BOOL)validateToolbarItem:(NSToolbarItem *)toolbarItem
+{
+    QString identifier = QString::fromNSString([toolbarItem itemIdentifier]);
+    QMacToolBarItem *item = toolBar->itemFor(identifier);
+    return toolBar->isEnabled(item);
+}
+
+- (NSToolbarItem *) toolbar: (NSToolbar *)toolbar itemForItemIdentifier: (NSString *) itemIdentifier willBeInsertedIntoToolbar:(BOOL) willBeInserted
+{
+    Q_UNUSED(toolbar);
+    Q_UNUSED(willBeInserted);
+    const QString identifier = QString::fromNSString(itemIdentifier);
+    QMacToolBarItem *toolButton = reinterpret_cast<QMacToolBarItem *>(identifier.toULongLong()); // string -> unisgned long long -> pointer
+    NSToolbarItem *toolbarItem = toolButton->nativeToolBarItem();
+
+    [toolbarItem setTarget:self];
+    [toolbarItem setAction:@selector(itemClicked:)];
+
+    return toolbarItem;
+}
+
+@end

--- a/src/qqutil/qqmactoolbarutils.h
+++ b/src/qqutil/qqmactoolbarutils.h
@@ -1,0 +1,46 @@
+/*
+ * qqmactoolbar.h
+ *
+ * (c) 2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/** @file qqutil/qqmactoolbar.h
+ * Header file for QQMacToolBarUtils
+ */
+
+#ifndef QQMACTOOLBAR_H
+#define QQMACTOOLBAR_H
+
+#include <QList>
+
+class QMacToolBar;
+class QMacToolBarItem;
+class QQToolBar;
+
+/**
+ * Utilities for QMacToolBar (from macextras) to perform some useful
+ * functions like set tooltips, save and restore toolbar customizations,
+ * etc.
+ */
+class QQMacToolBarUtils
+{
+public:
+    QQMacToolBarUtils();
+
+    static void copyState(QMacToolBar *src, QMacToolBar *dest);
+    static QString displayMode(QMacToolBar *toolBar);
+    static QString identifier(QMacToolBarItem *item);
+    static void setDelegate(QQToolBar *qqToolBar);
+    static void setDisplayMode(QMacToolBar *toolBar, const QString &displayMode);
+    static void setSizeMode(QMacToolBar *toolBar, const QString &sizeMode);
+    static void setToolTip(QMacToolBarItem *item, const QString &text);
+    static QString sizeMode(QMacToolBar *toolBar);
+    static QList<QMacToolBarItem *> includedItems(QMacToolBar *toolBar);
+};
+
+#endif

--- a/src/qqutil/qqmactoolbarutils.mm
+++ b/src/qqutil/qqmactoolbarutils.mm
@@ -1,0 +1,189 @@
+/*
+ * qqmactoolbar.mm
+ *
+ * (c) 2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/** @file qqutil/qqmactoolbar.cpp
+ * Source file for QQMacToolBarUtils
+ */
+
+#import <AppKit/AppKit.h>
+#include <QMacToolBar>
+#include <QMacToolBarItem>
+#include "qqmactoolbardelegate.h"
+#include "qqmactoolbarutils.h"
+#include "qqtoolbar.h"
+
+/**
+ * Constructor.  Never called in practice, all methods are static.
+ */
+QQMacToolBarUtils::QQMacToolBarUtils()
+{
+
+}
+
+/**
+ * Copy the appearance settings from one Mac toolbar to another.  Affects
+ * icon/text/both choice and icon size.
+ *
+ * @param src The toolbar whose settings are to be copied
+ * @param dest The toolbar whose settings are to be set
+ */
+void QQMacToolBarUtils::copyState(QMacToolBar *src, QMacToolBar *dest)
+{
+    if (!src || !dest) {
+        return;
+    }
+    [dest->nativeToolbar() setDisplayMode:[src->nativeToolbar() displayMode]];
+    [dest->nativeToolbar() setSizeMode:[src->nativeToolbar() sizeMode]];
+}
+
+/**
+ * Create and set the delegate for the given toolbar, in order to validate the
+ * enabled/disabled state of its items.
+ *
+ * @param toolBar The toolbar for which to set the delegate
+ */
+void QQMacToolBarUtils::setDelegate(QQToolBar *toolBar)
+{
+    QQMacToolbarDelegate *delegate = [[QQMacToolbarDelegate alloc] init];
+    delegate->toolBar = toolBar;
+    [toolBar->macToolBar()->nativeToolbar() setDelegate:delegate];
+}
+
+/**
+ * Get the current display mode of a toolbar for saving in the application
+ * preferences.
+ *
+ * @param toolBar The toolbar for which to fetch the display mode
+ * @return "iconAndLabel", "iconOnly", "labelOnly", or "default"
+ */
+QString QQMacToolBarUtils::displayMode(QMacToolBar *toolBar)
+{
+    NSToolbarDisplayMode mode = [toolBar->nativeToolbar() displayMode];
+    if (mode == NSToolbarDisplayModeIconAndLabel) {
+        return "iconAndLabel";
+    }
+    else if (mode == NSToolbarDisplayModeIconOnly) {
+        return "iconOnly";
+    }
+    else if (mode == NSToolbarDisplayModeLabelOnly) {
+        return "labelOnly";
+    }
+    else {
+        return "default";
+    }
+}
+
+/**
+ * Get the internal identifier string of a toolbar item.
+ *
+ * @param item The toolbar item for which to fetch the identifier
+ * @return An identifier string
+ */
+QString QQMacToolBarUtils::identifier(QMacToolBarItem *item)
+{
+    return QString::fromNSString([item->nativeToolBarItem() itemIdentifier]);
+}
+
+/**
+ * Set the display mode of a toolbar.
+ *
+ * @param toolBar The toolbar to be updated
+ * @param sizeMode "iconAndLabel", "iconOnly", "labelOnly" or "default"
+ */
+void QQMacToolBarUtils::setDisplayMode(QMacToolBar *toolBar, const QString &displayMode)
+{
+    NSToolbarDisplayMode mode;
+    if (displayMode == "iconAndLabel") {
+        mode = NSToolbarDisplayModeIconAndLabel;
+    }
+    else if (displayMode == "iconOnly") {
+        mode = NSToolbarDisplayModeIconOnly;
+    }
+    else if (displayMode == "labelOnly") {
+        mode = NSToolbarDisplayModeLabelOnly;
+    }
+    else {
+        mode = NSToolbarDisplayModeDefault;
+    }
+    [toolBar->nativeToolbar() setDisplayMode:mode];
+}
+
+/**
+ * Set the size mode of a toolbar (24 or 32 pixels).
+ *
+ * @param toolBar The toolbar to be updated
+ * @param sizeMode "regular", "small", or "default"
+ */
+void QQMacToolBarUtils::setSizeMode(QMacToolBar *toolBar, const QString &sizeMode)
+{
+    NSToolbarSizeMode mode;
+    if (sizeMode == "regular") {
+        mode = NSToolbarSizeModeRegular;
+    }
+    else if (sizeMode == "small") {
+        mode = NSToolbarSizeModeSmall;
+    }
+    else {
+        mode = NSToolbarSizeModeDefault;
+    }
+    [toolBar->nativeToolbar() setSizeMode:mode];
+}
+
+/**
+ * Set the tooltip of a toolbar item.
+ *
+ * @param item The toolbar item to be updated
+ * @param text The text to use for the tooltip
+ */
+void QQMacToolBarUtils::setToolTip(QMacToolBarItem *item, const QString &text)
+{
+    [item->nativeToolBarItem() setToolTip:text.toNSString()];
+}
+
+/**
+ * Get the current size mode of a toolbar for saving in the application
+ * preferences.
+ *
+ * @param toolBar The toolbar for which to fetch the size mode
+ * @return "regular", "small", or "default"
+ */
+QString QQMacToolBarUtils::sizeMode(QMacToolBar *toolBar)
+{
+    NSToolbarSizeMode mode = [toolBar->nativeToolbar() sizeMode];
+    if (mode == NSToolbarSizeModeRegular) {
+        return "regular";
+    }
+    else if (mode == NSToolbarSizeModeSmall) {
+        return "small";
+    }
+    else {
+        return "default";
+    }
+}
+
+/**
+ * Get the currently included toolbar items.  Need to ask the native toolbar
+ * directly, because QMacToolBar isn't informed of changes made in the
+ * customization menu.
+ *
+ * @param toolBar The toolbar for which to get an item listing
+ * @return The items included in the current toolbar configuration
+ */
+QList<QMacToolBarItem *> QQMacToolBarUtils::includedItems(QMacToolBar *toolBar)
+{
+    QList<QMacToolBarItem *> items;
+    for (NSToolbarItem *item in [toolBar->nativeToolbar() items]) {
+        QString identifier = QString::fromNSString([item itemIdentifier]);
+        QMacToolBarItem *toolButton = reinterpret_cast<QMacToolBarItem *>(identifier.toULongLong());
+        items.append(toolButton);
+    }
+    return items;
+}

--- a/src/qqutil/qqmainwindow.h
+++ b/src/qqutil/qqmainwindow.h
@@ -1,7 +1,7 @@
 /*
  * qqmainwindow.h
  *
- * (c) 2010 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2010,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -90,7 +90,6 @@ private:
 
 private:
     QString extension; /**< The extension of the document file type */
-    QToolBar *toolbar; /**< The application toolbar */
     QQMenuHelper *mh; /**< Support code for any document-based application */
     QString docPath; /**< Path of the current document file */
     QPrinter *printer; /**< The last-used printer settings (for this application instance) */

--- a/src/qqutil/qqmenuhelper.h
+++ b/src/qqutil/qqmenuhelper.h
@@ -1,7 +1,7 @@
 /*
  * qqmenuhelper.h
  *
- * (c) 2005-2010 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2005-2010,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@
 #include <QRegExp>
 #include <QStringList>
 
-#if defined(Q_WS_MAC)
+#if defined(Q_OS_MAC)
 #include <QStatusBar>
 #endif
 
@@ -30,7 +30,7 @@ class QAction;
 class QMainWindow;
 class QMenu;
 class QSettings;
-class QToolBar;
+class QQToolBar;
 
 #define MAX_RECENT_FILES 5
 
@@ -87,17 +87,18 @@ public:
         About = 13,
         AboutQt = 14
     };
-    QQMenuHelper(QMainWindow *window, QToolBar *toolbar,
-                 const QString &fileDescription, const QString &fileExtension,
+    QQMenuHelper(QMainWindow *window, const QString &fileDescription,
+                 const QString &fileExtension,
                  bool newFileLaunchesDialog=false);
 
     void loadSettings(QSettings *settings);
     void saveSettings(QSettings *settings);
     void updateRecentMenu();
-    void updateFileSelectorMenu();
-    void updateDocumentFileMenu();
+    void updateForFileSelector();
+    void updateForDocument();
     void addToFileMenu(QAction *action);
-    void addToToolBar(QAction *action);
+    void addToDocumentToolBar(QAction *action);
+    void addToFileSelectorToolBar(QAction *action);
     int saveChangesPrompt();
     QMenu *createMenu(QMainWindow *mainWindow);
     QMenu *fileMenu();
@@ -135,7 +136,8 @@ private:
 
 private:
     QMainWindow *mainWindow; /**< The main application window */
-    QToolBar *mainToolBar; /**< The main toolbar */
+    QQToolBar *documentToolBar; /**< The toolbar shown when a document is open */
+    QQToolBar *fileSelectorToolBar; /**< The toolbar for the file selector screen */
     QIcon docIcon; /**< The application document icon (used in Mac titlebar) */
     QIcon modifiedDocIcon; /**< The application document icon when there are unsaved changes */
     QString description; /**< The description of the document file type */

--- a/src/qqutil/qqtoolbar.cpp
+++ b/src/qqutil/qqtoolbar.cpp
@@ -1,0 +1,225 @@
+/*
+ * qqtoolbar.cpp
+ *
+ * (c) 2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/** @file qqutil/qqtoolbar.cpp
+ * Source file for QQToolBar
+ */
+
+#include <QAction>
+#include <QMainWindow>
+#include <QSettings>
+#include "qqtoolbar.h"
+#include "qqtoolbarstretch.h"
+
+#if defined(Q_OS_MAC)
+#include <QMacToolBar>
+#include <QMacToolBarItem>
+#include <QWindow>
+#include "qqmactoolbarutils.h"
+#else
+#include <QToolBar>
+#endif
+
+QQToolBar *QQToolBar::currentToolBar = 0;
+
+/**
+ * Constructor.
+ *
+ * @param parent The main window to which the toolbar will be attached
+ * @param name The name of the toolbar (must be different for each one, and
+ *             should be valid as a QSettings group name)
+ */
+QQToolBar::QQToolBar(QMainWindow *parent, const QString &name)
+  : QObject(parent), mainWindow(parent), identifier(name)
+{
+#if defined(Q_OS_MAC)
+    toolBar = new QMacToolBar(name, parent);
+    // Make sure each toolbar is attached so it can be cleaned up before exit
+    mainWindow->window()->winId();
+    QQMacToolBarUtils utils;
+    utils.setDelegate(this);
+#else
+    toolBar = mainWindow->addToolBar(name);
+    toolBar->setObjectName(name);
+    toolBar->toggleViewAction()->setEnabled(false);
+    toolBar->toggleViewAction()->setVisible(false);
+#endif
+}
+
+#if defined(Q_OS_MAC)
+/**
+ * Convert a Mac toolbar item activation signal into a triggered signal for
+ * the original QAction.
+ */
+void QQToolBar::activated()
+{
+    QMacToolBarItem *item = static_cast<QMacToolBarItem *>(sender());
+    QAction *action = itemActionMap[item];
+    if (action->isCheckable()) {
+        action->toggle();
+        emit action->triggered(action->isChecked());
+    }
+    else {
+        emit action->triggered();
+    }
+}
+
+/**
+ * Determine if the specified toolbar item should currently be enabled.
+ * Based on the state of the corresponding QAction.
+ *
+ * @param item A toolbar item
+ * @return true if the item should be enabled, false otherwise
+ */
+bool QQToolBar::isEnabled(QMacToolBarItem *item)
+{
+    if (!item || !itemActionMap.contains(item)) {
+        return true;
+    }
+    QAction *action = itemActionMap[item];
+    return action->isEnabled();
+}
+
+/**
+ * Get the QMacToolBarItem which wraps the NSToolbarItem with the given identifier.
+ *
+ * @param identifier The identifier of the NSToolbarItem whose Qt wrapper is desired
+ * @return The corresponding Qt wrapper item, or zero if none exists
+ */
+QMacToolBarItem *QQToolBar::itemFor(const QString &identifier)
+{
+    if (!(nativeItemMap.contains(identifier))) {
+        return 0;
+    }
+    return nativeItemMap[identifier];
+}
+
+/**
+ * Get the QMacToolBar associated with this toolbar.
+ *
+ * @return The underlying QMacToolBar
+ */
+QMacToolBar *QQToolBar::macToolBar()
+{
+    return toolBar;
+}
+#endif
+
+/**
+ * Add an action to the toolbar.  Correctly accounts for quirks on Maemo and
+ * Mac OS X.
+ *
+ * @param action The action to be added
+ */
+void QQToolBar::add(QAction *action)
+{
+#if defined(Q_WS_HILDON) || defined(Q_WS_MAEMO_5)
+    new QQToolBarStretch(toolBar, action);
+#endif
+#if defined (Q_OS_MAC)
+    // Remove any trailing ellipsis
+    QString text = action->text().remove(QChar(8230));
+    QMacToolBarItem *item = toolBar->addItem(action->icon(), text);
+    item->setObjectName(action->objectName());
+    item->setSelectable(action->isCheckable());
+    QQMacToolBarUtils::setToolTip(item, text);
+    itemActionMap[item] = action;
+    QString identifier = QQMacToolBarUtils::identifier(item);
+    nativeItemMap[identifier] = item;
+    connect(item, &QMacToolBarItem::activated, this, &QQToolBar::activated);
+#else
+    toolBar->addAction(action);
+#endif
+#if defined(Q_WS_HILDON) || defined(Q_WS_MAEMO_5)
+    new QQToolBarStretch(toolBar, action);
+#endif
+}
+
+/**
+ * Load saved toolbar configuration options.  Primarily called by
+ * QQMenuHelper, and currently only does anything on Mac OS X (where it
+ * handles icon size, icon and/or text preference, and the set of buttons
+ * currently shown).
+ *
+ * @param settings The QSettings object from which to load the settings.
+ */
+void QQToolBar::loadSettings(QSettings *settings)
+{
+#if defined(Q_OS_MAC)
+    settings->beginGroup(identifier);
+    QString displayMode = settings->value("displayMode").toString();
+    QQMacToolBarUtils::setDisplayMode(toolBar, displayMode);
+    QString sizeMode = settings->value("sizeMode").toString();
+    QQMacToolBarUtils::setSizeMode(toolBar, sizeMode);
+    QVariant itemNames = settings->value("items");
+    if (!(itemNames.isNull())) {
+        QHash<QString, QMacToolBarItem *> nameToItem;
+        foreach(QMacToolBarItem *item, toolBar->allowedItems()) {
+            nameToItem[item->objectName()] = item;
+        }
+        QList<QMacToolBarItem *> items;
+        foreach(QString itemName, itemNames.toStringList()) {
+            if (nameToItem.contains(itemName)) {
+                items.append(nameToItem.value(itemName));
+            }
+        }
+        toolBar->setItems(items);
+    }
+    settings->endGroup();
+#else
+    Q_UNUSED(settings);
+#endif
+}
+
+/**
+ * Save the toolbar's current configuration so it can be restored the next
+ * time the application is run.
+ *
+ * @param settings the QSettings object to be updated
+ */
+void QQToolBar::saveSettings(QSettings *settings)
+{
+#if defined(Q_OS_MAC)
+    settings->beginGroup(identifier);
+    settings->setValue("displayMode", QQMacToolBarUtils::displayMode(toolBar));
+    settings->setValue("sizeMode", QQMacToolBarUtils::sizeMode(toolBar));
+    QStringList itemNames;
+    foreach (QMacToolBarItem *item, QQMacToolBarUtils::includedItems(toolBar)) {
+        itemNames.append(item->objectName());
+    }
+    settings->setValue("items", itemNames);
+    settings->endGroup();
+#else
+    Q_UNUSED(settings);
+#endif
+}
+
+/**
+ * Show this toolbar.  Hides any other toolbar which may currently be visible.
+ */
+void QQToolBar::show()
+{
+    if (QQToolBar::currentToolBar == this) {
+        return;
+    }
+#if defined(Q_OS_MAC)
+    if (QQToolBar::currentToolBar) {
+        QQMacToolBarUtils::copyState(QQToolBar::currentToolBar->toolBar, toolBar);
+    }
+    toolBar->attachToWindow(mainWindow->window()->windowHandle());
+#else
+    if (QQToolBar::currentToolBar) {
+        QQToolBar::currentToolBar->toolBar->hide();
+    }
+    toolBar->show();
+#endif
+    QQToolBar::currentToolBar = this;
+}

--- a/src/qqutil/qqtoolbar.h
+++ b/src/qqutil/qqtoolbar.h
@@ -1,0 +1,70 @@
+/*
+ * qqtoolbar.h
+ *
+ * (c) 2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/** @file qqutil/qqtoolbar.h
+ * Header file for QQToolBar
+ */
+
+#ifndef QQTOOLBAR_H
+#define QQTOOLBAR_H
+
+#include <QObject>
+
+class QAction;
+class QMainWindow;
+class QSettings;
+
+#if defined(Q_OS_MAC)
+#include <QMap>
+class QMacToolBar;
+class QMacToolBarItem;
+#else
+class QToolBar;
+#endif
+
+/**
+ * A toolbar that behaves correctly across different platforms, including
+ * Mac OS X and Maemo.  Is not itself a QWidget, as it wraps various underlying
+ * toolbar implementations.
+ */
+class QQToolBar: public QObject
+{
+    Q_OBJECT
+public:
+    QQToolBar(QMainWindow *parent, const QString &name);
+
+    void add(QAction *action);
+    void loadSettings(QSettings *settings);
+    void saveSettings(QSettings *settings);
+    void show();
+#if defined(Q_OS_MAC)
+    bool isEnabled(QMacToolBarItem *item);
+    QMacToolBarItem *itemFor(const QString &identifier);
+    QMacToolBar *macToolBar();
+private slots:
+    void activated();
+#endif
+
+private:
+    QMainWindow *mainWindow; /**< The application's main window */
+    QString identifier; /**< The name used to identify this toolbar in saved settings */
+    static QQToolBar *currentToolBar; /**< The currently displayed toolbar, if any */
+#if defined(Q_OS_MAC)
+    QMacToolBar *toolBar; /**< Toolbar on Mac OS X */
+    void *validator; /**< Mac OS X toolbar item disabler */
+    QMap<QMacToolBarItem*,QAction*> itemActionMap; /**< Mapping of toolbar items to source actions */
+    QMap<QString,QMacToolBarItem*> nativeItemMap; /**< Mapping of native toolbar item identifiers to Qt toolbar items */
+#else
+    QToolBar *toolBar; /**< Toolbar on non-Mac platforms */
+#endif
+};
+
+#endif

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1,7 +1,7 @@
 /*
  * view.cpp
  *
- * (c) 2002-2004,2009-2013 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2002-2004,2009-2013,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,6 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QLocale>
-#include <QTextDocument>
 #include <QTextStream>
 #include "csvutils.h"
 #include "database.h"
@@ -534,7 +533,7 @@ void View::exportToHTML(const QString &filename)
     int i, j;
     QString headerPattern("<th>%1</th>\n");
     for (i = 0; i < colCount; i++) {
-        lines.append(headerPattern.arg(Qt::escape(columns[i])));
+        lines.append(headerPattern.arg(Formatting::toHtmlEscaped(columns[i])));
     }
     QFile f(filename);
     if (!f.open(QFile::WriteOnly)) {
@@ -575,7 +574,7 @@ void View::exportToHTML(const QString &filename)
                 output << divs[2];
             }
             else if (type == NOTE || type == STRING) {
-                value = Qt::escape(data[j]).replace(newline, br);
+                value = Formatting::toHtmlEscaped(data[j]).replace(newline, br);
                 output << leftPattern.arg(value);
             }
             else {

--- a/src/viewdisplay.cpp
+++ b/src/viewdisplay.cpp
@@ -1,7 +1,7 @@
 /*
  * viewdisplay.cpp
  *
- * (c) 2002-2004,2008-2013 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2002-2004,2008-2013,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,7 +24,6 @@
 #include <QSpinBox>
 #include <QStackedWidget>
 #include <QStringList>
-#include <QTextDocument>
 #include <QTimer>
 #include <QToolButton>
 #include <QTreeWidget>
@@ -35,6 +34,7 @@
 #include "datamodel.h"
 #include "datatypes.h"
 #include "factory.h"
+#include "formatting.h"
 #include "noteeditor.h"
 #include "pbmaemo5style.h"
 #include "portabase.h"
@@ -99,9 +99,15 @@ ViewDisplay::ViewDisplay(PortaBase *pbase, QWidget *parent) : QWidget(parent),
             this, SLOT(cellReleased(const QModelIndex &)));
 
     QHeaderView *header = table->header();
+#if QT_VERSION >= 0x050000
+    header->setSectionsClickable(true);
+    header->setSectionsMovable(false);
+    header->setSectionResizeMode(QHeaderView::Interactive);
+#else
     header->setClickable(true);
     header->setMovable(false);
     header->setResizeMode(QHeaderView::Interactive);
+#endif
     connect(header, SIGNAL(sectionPressed(int)), this, SLOT(headerPressed(int)));
     connect(header, SIGNAL(sectionClicked(int)), this, SLOT(headerReleased(int)));
     connect(header, SIGNAL(sectionResized(int, int, int)),
@@ -316,7 +322,7 @@ QString ViewDisplay::toPrintHTML()
     int i, j;
     QString cellPattern("<th align=\"left\">%1</th>");
     for (i = 0; i < colCount; i++) {
-        result += cellPattern.arg(Qt::escape(colNames[i]));
+        result += cellPattern.arg(Formatting::toHtmlEscaped(colNames[i]));
     }
     result += "</tr></thead><tbody>";
     int rowCount = view->totalRowCount();
@@ -355,7 +361,7 @@ QString ViewDisplay::toPrintHTML()
                 value = imgTags[2];
             }
             else if (type == NOTE || type == STRING) {
-                value = Qt::escape(value).replace(newline, br);
+                value = Formatting::toHtmlEscaped(value).replace(newline, br);
             }
             result += cellPattern.arg(align).arg(value);
         }

--- a/src/xmlexport.cpp
+++ b/src/xmlexport.cpp
@@ -1,7 +1,7 @@
 /*
  * xmlexport.cpp
  *
- * (c) 2003,2009-2010 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003,2009-2010,2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  */
 
 #include <QFile>
-#include <QTextDocument>
 #include <QTextStream>
 #include "database.h"
 #include "datatypes.h"
@@ -239,6 +238,6 @@ QString XMLExport::getValue(c4_View &view, const QString &name, char type, int r
     else {
         c4_StringProp prop(name.toUtf8());
         QString value = QString::fromUtf8(prop (view[row]));
-        return Qt::escape(value);
+        return Formatting::toHtmlEscaped(value);
     }
 }

--- a/src/xmlimport.cpp
+++ b/src/xmlimport.cpp
@@ -1,7 +1,7 @@
 /*
  * xmlimport.cpp
  *
- * (c) 2003,2009-2010,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003,2009-2010,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -113,7 +113,7 @@ XMLImport::XMLImport(Database *dbase) : QObject(), QXmlDefaultHandler(),
  *
  * @return An error message, or an empty string if none
  */
-QString XMLImport::errorString()
+QString XMLImport::errorString() const
 {
     return error;
 }

--- a/src/xmlimport.h
+++ b/src/xmlimport.h
@@ -1,7 +1,7 @@
 /*
  * xmlimport.h
  *
- * (c) 2003,2009,2015 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2003,2009,2015-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,7 +52,7 @@ public:
     bool endElement(const QString &namespaceURI, const QString &localName,
                     const QString &qName);
     bool characters (const QString &ch);
-    QString errorString();
+    QString errorString() const;
     QString formattedError();
     bool fatalError(const QXmlParseException &exception);
     void setDocumentLocator(QXmlLocator *locator);


### PR DESCRIPTION
Added support for Qt 5 to get the latest fixes for actively supported platforms and enable ports to new ones, without yet dropping Qt 4 support (needed for Maemo devices).  Also used and extended QMacToolBar to get a native toolbar on Mac OS X, complete with the usual customization options.