### PR TITLE
Finished optional import of new enum options from CSV

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-2017-01-11  JMB  Better alternating row color defaults
+2017-01-11  JMB  Better alternating row color defaults, CSV enums import
 
     The background colors for alternate rows in the data viewer and
     other grids had been defaulting to white and light gray, but now
@@ -8,6 +8,10 @@
     but the color from the preferences dialog is now used.  There is also
     now a "Reset" button in the dialog to revert to the current system
     default colors.
+
+    Also, I discovered that I hadn't quite finished support for optionally
+    importing new enum values during CSV import with the initial commit back
+    in 2013; it is now finished and tested.
 
 2017-01-09  JMB  Added Italian UI translation, updated translation files
 

--- a/resources/help/command_line.txt
+++ b/resources/help/command_line.txt
@@ -42,7 +42,7 @@ The following options can be used with either ``fromcsv`` or ``tocsv``:
 
 There's one additional option for ``fromcsv``:
 
---add-to-enums  Automatically add new enum values encountered
+--add-unknown-enum-options  Automatically add new enum values encountered
 
 There's also one additional option for ``tocsv``:
 

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -116,7 +116,7 @@ int CommandLine::fromOtherFormat(const QStringList &args)
     int passIndex = parseOption("-p");
     int encIndex = parseOption("-e");
     int delIndex = parseOption("-d");
-    int enumsIndex = parseOption("--add-unknown-enum-options");
+    int enumsIndex = parseOption("--add-unknown-enum-options", false);
     int headersIndex = parseOption("--headers", false);
     if (passIndex == -2 || encIndex == -2 || delIndex == -2
         || enumsIndex == -2 || headersIndex == -2 || argc != numArgs) {
@@ -186,7 +186,8 @@ int CommandLine::fromOtherFormat(const QStringList &args)
                 delimiter = delimArg[0];
             }
         }
-        CSVUtils csv(delimiter, encoding, headersIndex != -1);
+        CSVUtils csv(delimiter, encoding, headersIndex != -1, "\n",
+                     enumsIndex != -1);
         QStringList result = db->importFromCSV(sourceFile, &csv);
         int count = result.count();
         if (count > 0) {

--- a/src/csvutils.cpp
+++ b/src/csvutils.cpp
@@ -33,6 +33,8 @@
  *                headers
  * @param lineEnding The character(s) used to designate the end of a record
  *                   (only when writing)
+ * @param addNewEnumOptions True if new option values should be automatically
+ *                          added to enums when encountered during import
  */
 CSVUtils::CSVUtils(QChar delimiter, const QString &encoding, bool headers,
                    const QString &lineEnding, bool addNewEnumOptions)
@@ -384,7 +386,7 @@ bool CSVUtils::addRow(Database *db)
             }
         }
     }
-    message = db->addRow(row, &rowId, false, true);
+    message = db->addRow(row, &rowId, false, true, m_add_options);
     if (!message.isEmpty()) {
         message = QObject::tr("Error in row %1").arg(rowNum) + "\n" + message;
         return false;


### PR DESCRIPTION
I discovered that I hadn't quite finished support for optionally importing new enum values during CSV import with the initial commit back in 2013; it is now finished and tested.