### PR TITLE
Dynamically update fullscreen action text

### DIFF
--- a/src/menuactions.cpp
+++ b/src/menuactions.cpp
@@ -146,7 +146,9 @@ MenuActions::MenuActions(QObject *parent)
 
     objectNameMap.insert(Fullscreen, "Fullscreen");
     textMap.insert(Fullscreen, tr("Fullscreen"));
+    textMap.insert(ExitFullscreen, tr("Exit Fullscreen"));
     toolTipMap.insert(Fullscreen, tr("View PortaBase in fullscreen mode"));
+    toolTipMap.insert(ExitFullscreen, tr("Exit fullscreen mode"));
 }
 
 /**
@@ -158,6 +160,16 @@ MenuActions::MenuActions(QObject *parent)
 QString MenuActions::menuText(Item item)
 {
     return QQMenuHelper::menuText(textMap[item]);
+}
+
+/**
+ * Get the translation for the tooltip of the specified menu or action.
+ *
+ * @param item The identifier of the desired menu or action
+ */
+QString MenuActions::toolTipText(Item item)
+{
+    return toolTipMap[item];
 }
 
 /**

--- a/src/menuactions.h
+++ b/src/menuactions.h
@@ -77,7 +77,8 @@ public:
         Views,
         Sortings,
         Filters,
-        Fullscreen
+        Fullscreen,
+        ExitFullscreen
     };
     typedef QMap< Item, QString > PhraseMap;
     typedef QMap< Item, QKeySequence > ShortcutMap;
@@ -85,6 +86,7 @@ public:
     explicit MenuActions(QObject *parent=0);
 
     QString menuText(Item item);
+    QString toolTipText(Item item);
     QAction *action(Item item, bool toggle=false);
     QAction *action(Item item, const QIcon &icon);
 

--- a/src/portabase.cpp
+++ b/src/portabase.cpp
@@ -1455,6 +1455,35 @@ void PortaBase::setRowSelected(bool y)
 }
 
 /**
+ * Switch from normal mode to fullscreen or vice versa.
+ */
+void PortaBase::toggleFullscreen()
+{
+    if (isFullScreen()) {
+        showNormal();
+        QAction *action = qobject_cast<QAction *>(sender());
+        action->setText(ma->menuText(MenuActions::Fullscreen));
+        QString toolTip = ma->toolTipText(MenuActions::Fullscreen);
+        action->setToolTip(toolTip);
+        action->setStatusTip(toolTip);
+#if defined(Q_OS_ANDROID)
+        action->setIcon(Factory::icon("fullscreen"));
+#endif
+    }
+    else {
+        showFullScreen();
+        QAction *action = qobject_cast<QAction *>(sender());
+        action->setText(ma->menuText(MenuActions::ExitFullscreen));
+        QString toolTip = ma->toolTipText(MenuActions::ExitFullscreen);
+        action->setToolTip(toolTip);
+        action->setStatusTip(toolTip);
+#if defined(Q_OS_ANDROID)
+        action->setIcon(Factory::icon("fullscreen_exit"));
+#endif
+    }
+}
+
+/**
  * Load the main application settings, already set to read from the
  * top-level "portabase" group.  May be empty if this is the first time
  * running PortaBase in this environment.

--- a/src/portabase.h
+++ b/src/portabase.h
@@ -99,6 +99,7 @@ private slots:
     void changeView();
     void changeSorting();
     void changeFilter();
+    void toggleFullscreen();
 
 private:
     void createFile(ImportDialog::DataSource source, const QString &file=QString::null);

--- a/src/qqutil/actionbar.cpp
+++ b/src/qqutil/actionbar.cpp
@@ -31,6 +31,7 @@ ActionBar::ActionBar(QWidget *parent) : QWidget(parent) {
             "* {background:lightGray}"
             "QToolButton {height: %3px; min-width: %2px}"
             "QToolButton QMenu::item {padding: %1px %1px %1px %1px; border: 1px solid transparent}"
+            "QToolButton QMenu::indicator {image: none}"
             "QToolButton QMenu::item::selected {border-color: black}"
             "QToolButton#viewControl {font:bold}"
             "QToolButton::menu-indicator {image: none}").arg(paddingPixels).arg(minWidth);

--- a/src/qqutil/qqmainwindow.cpp
+++ b/src/qqutil/qqmainwindow.cpp
@@ -142,27 +142,6 @@ void QQMainWindow::saveWindowSettings(QSettings *settings)
 }
 
 /**
- * Switch from normal mode to fullscreen or vice versa.
- */
-void QQMainWindow::toggleFullscreen()
-{
-    if (isFullScreen()) {
-        showNormal();
-#if defined(Q_OS_ANDROID)
-        QAction *action = qobject_cast<QAction *>(sender());
-        action->setIcon(QIcon(":/icons/fullscreen.svg"));
-#endif
-    }
-    else {
-        showFullScreen();
-#if defined(Q_OS_ANDROID)
-        QAction *action = qobject_cast<QAction *>(sender());
-        action->setIcon(QIcon(":/icons/fullscreen_exit.svg"));
-#endif
-    }
-}
-
-/**
  * Get the path of the currently open document.
  */
 QString QQMainWindow::documentPath()

--- a/src/qqutil/qqmainwindow.h
+++ b/src/qqutil/qqmainwindow.h
@@ -64,7 +64,6 @@ protected slots:
      */
     virtual void print(QPrinter *p) = 0;
     void quit();
-    void toggleFullscreen();
 
 protected:
     void closeEvent(QCloseEvent *e);


### PR DESCRIPTION
The fullscreen action now changes the text in menus and tooltips appropriately after it has been activated (to say "Exit Fullscreen" instead of "Fullscreen", etc.).  Additionally, I'd overlooked that a small checkbox was been shown next to the text in the menu on Android devices; suppressed that now that the action's text is more appropriate.