### PR TITLE
Remember more recent files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+2017-03-19  JMB  More recent files remembered
+
+    Increased the number of recent files shown in the File menu and on
+    the file selection screen from 5 to 10.  Also abbreviated the text
+    on the file import button to better fit in portrait mode on Android
+    phones.
+
 2017-03-17  JMB  Dynamically update fullscreen action text
 
     The fullscreen action now changes the text in menus and tooltips

--- a/src/menuactions.cpp
+++ b/src/menuactions.cpp
@@ -40,7 +40,7 @@ MenuActions::MenuActions(QObject *parent)
 
     objectNameMap.insert(Import, "Import");
     textMap.insert(Import, tr("&Import") + ellipsis);
-    toolTipMap.insert(Import, tr("Import a file from another format"));
+    toolTipMap.insert(Import, tr("Import a file"));
 
     textMap.insert(ImportCSV, tr("&Import") + ellipsis);
     toolTipMap.insert(ImportCSV, tr("Import rows from a CSV file"));

--- a/src/portabase.cpp
+++ b/src/portabase.cpp
@@ -336,6 +336,16 @@ PortaBase::PortaBase(QWidget *parent)
             mh->action(QQMenuHelper::Recent4), SIGNAL(triggered()));
     connect(recentButtons[4], SIGNAL(clicked()),
             mh->action(QQMenuHelper::Recent5), SIGNAL(triggered()));
+    connect(recentButtons[5], SIGNAL(clicked()),
+            mh->action(QQMenuHelper::Recent6), SIGNAL(triggered()));
+    connect(recentButtons[6], SIGNAL(clicked()),
+            mh->action(QQMenuHelper::Recent7), SIGNAL(triggered()));
+    connect(recentButtons[7], SIGNAL(clicked()),
+            mh->action(QQMenuHelper::Recent8), SIGNAL(triggered()));
+    connect(recentButtons[8], SIGNAL(clicked()),
+            mh->action(QQMenuHelper::Recent9), SIGNAL(triggered()));
+    connect(recentButtons[9], SIGNAL(clicked()),
+            mh->action(QQMenuHelper::Recent10), SIGNAL(triggered()));
     vlayout->addWidget(recentBox);
     vlayout->addStretch(1);
     hlayout->addStretch(1);
@@ -688,6 +698,11 @@ void PortaBase::updateRecentFileButtons()
     recentFiles << mh->action(QQMenuHelper::Recent3)->text();
     recentFiles << mh->action(QQMenuHelper::Recent4)->text();
     recentFiles << mh->action(QQMenuHelper::Recent5)->text();
+    recentFiles << mh->action(QQMenuHelper::Recent6)->text();
+    recentFiles << mh->action(QQMenuHelper::Recent7)->text();
+    recentFiles << mh->action(QQMenuHelper::Recent8)->text();
+    recentFiles << mh->action(QQMenuHelper::Recent9)->text();
+    recentFiles << mh->action(QQMenuHelper::Recent10)->text();
     for (int i = 0; i < MAX_RECENT_FILES; i++) {
         QString path = recentFiles[i];
         QFileInfo info(path);

--- a/src/qqutil/qqmenuhelper.cpp
+++ b/src/qqutil/qqmenuhelper.cpp
@@ -215,6 +215,11 @@ QQMenuHelper::QQMenuHelper(QMainWindow *window, const QString &fileDescription,
     actions[Recent3] = recentActions[2];
     actions[Recent4] = recentActions[3];
     actions[Recent5] = recentActions[4];
+    actions[Recent6] = recentActions[5];
+    actions[Recent7] = recentActions[6];
+    actions[Recent8] = recentActions[7];
+    actions[Recent9] = recentActions[8];
+    actions[Recent10] = recentActions[9];
     actions[Separator] = fileSeparatorAction;
     actions[Close] = closeAction;
     actions[Preferences] = prefsAction;

--- a/src/qqutil/qqmenuhelper.h
+++ b/src/qqutil/qqmenuhelper.h
@@ -32,7 +32,7 @@ class QMenu;
 class QSettings;
 class QQToolBar;
 
-#define MAX_RECENT_FILES 5
+#define MAX_RECENT_FILES 10
 
 /**
  * Helps create and manage the menus for a typical document-based
@@ -79,13 +79,18 @@ public:
         Recent3 = 5,
         Recent4 = 6,
         Recent5 = 7,
-        Separator = 8,
-        Close = 9,
-        Preferences = 10,
-        Quit = 11,
-        Help = 12,
-        About = 13,
-        AboutQt = 14
+        Recent6 = 8,
+        Recent7 = 9,
+        Recent8 = 10,
+        Recent9 = 11,
+        Recent10 = 12,
+        Separator = 13,
+        Close = 14,
+        Preferences = 15,
+        Quit = 16,
+        Help = 17,
+        About = 18,
+        AboutQt = 19
     };
     QQMenuHelper(QMainWindow *window, const QString &fileDescription,
                  const QString &fileExtension,
@@ -146,7 +151,7 @@ private:
     QAction *fileNewAction; /**< Action for creating a new file */
     QAction *fileOpenAction; /**< Action for opening an existing file */
     QAction *fileSaveAction; /**< Action for saving the current file */
-    QAction* recentActions[5]; /**< Actions for opening recently used files */
+    QAction* recentActions[MAX_RECENT_FILES]; /**< Actions for opening recently used files */
     QList<QAction *> extraFileActions; /**< Additional actions added to the File menu by the application */
     QAction *fileSeparatorAction; /**< Separator that appears before "Close" in the "File" menu */
     QAction *closeAction; /**< Action for closing an open document */


### PR DESCRIPTION
Increased the number of recent files shown in the File menu and on the file selection screen from 5 to 10.  Also abbreviated the text on the file import button to better fit in portrait mode on Android phones.