### PR TITLE
Remove image resolution limit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,17 @@
+2017-03-20  JMB  Removed image resolution limit
+
+    All of PortaBase's supported platforms now have much more RAM than
+    the original Sharp Zaurus (and Qt has gotten better about downscaling
+    PNG images while loading), so the 800x600 resolution cap no longer
+    makes sense.  The limit has been removed; images smaller than the
+    screen resolution are shown at their actual size, and larger ones are
+    scaled down to fit on the screen.  This means, for example, that digital
+    photos can now be stored in a PortaBase file and (if the file wasn't
+    explicitly altered in the image editor when selecting it) exported out
+    again with no quality loss and all metadata intact.  Note, however,
+    that Metakit's 1 GB file size limit significantly constrains the
+    number of high-resolution photos you can fit in a single PortaBase file.
+
 2017-03-19  JMB  More recent files remembered
 
     Increased the number of recent files shown in the File menu and on

--- a/README.rst
+++ b/README.rst
@@ -137,8 +137,7 @@ structures, and communication with the operating system.  It also uses:
   (http://beecrypt.sourceforge.net/)
 - A modified version of the calculator widget from KMyMoney
   (https://kmymoney.org/)
-- A modified version of QtActionBar (https://github.com/mbnoimi/QtActionBar)
-  for the Android release
+- QtActionBar (https://github.com/mbnoimi/QtActionBar) for the Android release
 
 Additional software is used to package PortaBase on its various platforms:
 

--- a/resources/help/image_editor.txt
+++ b/resources/help/image_editor.txt
@@ -18,5 +18,3 @@ An Image column stores pictures imported from JPEG or PNG image files.  After yo
   Apply the currently displayed settings and update the image preview accordingly.
 
 Click "OK"/"Done" to store the image as it is shown, or cancel out of the dialog to leave the field unchanged.
-
-.. note:: Because memory was limited on the Zaurus PDAs for which PortaBase was originally developed, very large pictures will be rejected.  JPEG images larger than 6400 x 4800 pixels cannot be imported, and ones larger than 800 x 600 will be shrunk to at most that size.  Similarly, PNG images larger than 800 x 600 cannot be imported.  These limitations will be removed in a future version of PortaBase, since it is no longer being developed for the Zaurus.

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1493,14 +1493,13 @@ QString Database::addRow(const QStringList &values, int *rowId,
                     return QObject::tr("Missing file") + ":\n" + value;
                 }
                 ImageUtils utils;
-                bool resized = false;
-                QImage image = utils.load(path, &resized);
+                QImage image = utils.load(path);
                 if (image.isNull()) {
                     return utils.getErrorMessage() + ":\n" + value;
                 }
                 QString format = utils.getFormat();
                 QByteArray data = ImageUtils::getImageData(image, format, path,
-                                                           resized);
+                                                           false);
                 prop (row) = c4_Bytes(data.data(), data.size());
                 stringProp (row) = format.toUtf8();
             }

--- a/src/image/imageeditor.cpp
+++ b/src/image/imageeditor.cpp
@@ -25,6 +25,7 @@
 #include <QScrollArea>
 #include <QWidget>
 #include "imageeditor.h"
+#include "imageutils.h"
 #include "imagewidget.h"
 #include "../qqutil/qqfactory.h"
 #include "../qqutil/qqspinbox.h"
@@ -42,11 +43,11 @@ ImageEditor::ImageEditor(QWidget *parent)
     vbox->addWidget(paramsRow);
     hbox->addWidget(new QLabel(tr("Width"), paramsRow));
     widthBox = new QQSpinBox(paramsRow);
-    widthBox->setRange(1, 800);
+    widthBox->setRange(1, 10000);
     hbox->addWidget(widthBox);
     hbox->addWidget(new QLabel(tr("Height"), paramsRow));
     heightBox = new QQSpinBox(paramsRow);
-    heightBox->setRange(1, 600);
+    heightBox->setRange(1, 10000);
     hbox->addWidget(heightBox);
 
     hbox->addWidget(new QLabel(tr("Rotate"), paramsRow));
@@ -87,28 +88,12 @@ int ImageEditor::edit(const QString &file)
     oldHeight = size.height();
     int width = oldWidth;
     int height = oldHeight;
-    // Scale the image down so as to not swamp devices with limited memory when
-    // loaded (only works for JPEGs, big PNG images will be rejected)
-    int scaleDenom = 1;
-    while (width * height > 800 * 600) {
-        scaleDenom *= 2;
-        // I doubt if many people have 6400 x 4800 images, but it's probably
-        // only a matter of time before digital cameras get there...
-        if (scaleDenom > 8 || format != "JPEG") {
-            QMessageBox::warning(this, qApp->applicationName(),
-                                 tr("Image is too large to import"));
-            return QDialog::Rejected;
-        }
-        width /= 2;
-        height /= 2;
-    }
     widthBox->setMaximum(width);
     widthBox->setValue(width);
     heightBox->setMaximum(height);
     heightBox->setValue(height);
     rotateBox->setCurrentIndex(0);
-    reader.setScaledSize(QSize(width, height));
-    image = reader.read();
+    image = ImageUtils::readImage(&reader);
     qApp->processEvents();
     QPixmap pm = QPixmap::fromImage(image);
     display->setPixmap(pm);

--- a/src/image/imageeditor.h
+++ b/src/image/imageeditor.h
@@ -28,9 +28,7 @@ class QWidget;
 /**
  * Dialog for editing the properties of an image that will be stored in a
  * %PortaBase file.  The image can be resized and/or rotated before saving
- * it in the database.  Currently a maximum size of 800x600 is enforced (the
- * Sharp Zaurus can't display anything much bigger than that before running
- * out of memory).
+ * it in the database.
  */
 class ImageEditor: public PBDialog
 {

--- a/src/image/imageutils.h
+++ b/src/image/imageutils.h
@@ -21,6 +21,7 @@
 #include <QString>
 
 class Database;
+class QImageReader;
 
 /**
  * Utilities for loading and exporting images.
@@ -32,11 +33,12 @@ public:
 
     static QImage load(Database *db, int rowId, const QString &colName,
                        const QString &format);
-    QImage load(const QString &path, bool *resized);
+    QImage load(const QString &path);
     QString getFormat() const;
     QString getErrorMessage() const;
     static QByteArray getImageData(QImage image, const QString &format,
                               const QString &path, bool changed);
+    static QImage readImage(QImageReader *reader);
     void setExportPaths(const QString &filePath);
     QString exportImage(Database *db, int rowId, const QString &columnName,
                         const QString &format);


### PR DESCRIPTION
All of PortaBase's supported platforms now have much more RAM than the original Sharp Zaurus (and Qt has gotten better about downscaling PNG images while loading), so the 800x600 resolution cap no longer makes sense.  The limit has been removed; images smaller than the screen resolution are shown at their actual size, and larger ones are scaled down to fit on the screen.  This means, for example, that digital photos can now be stored in a PortaBase file and (if the file wasn't explicitly altered in the image editor when selecting it) exported out again with no quality loss and all metadata intact.  Note, however, that Metakit's 1 GB file size limit significantly constrains the number of high-resolution photos you can fit in a single PortaBase file.