### PR TITLE
Better image fullscreen mode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+2017-03-22  JMB  Better image fullscreen mode
+
+    PortaBase was still using a hack for fullscreen image display that
+    predated the addition of proper fullscreen support in Qt, and at
+    least with Qt 5 it sometimes resulted in odd failures to return to
+    normal display mode.  Switched over to the same approach used for
+    the main window's fullscreen mode.
+
 2017-03-20  JMB  Removed image resolution limit
 
     All of PortaBase's supported platforms now have much more RAM than

--- a/src/image/imageviewer.h
+++ b/src/image/imageviewer.h
@@ -22,6 +22,7 @@
 
 class ImageWidget;
 class QDialogButtonBox;
+class QScrollArea;
 class View;
 
 /**
@@ -40,14 +41,19 @@ public:
     void setImage(const QImage &image);
     void setView(View *view, int row, int column);
 
+public slots:
+    void showFullScreen();
+    void showNormal();
+
 protected:
+    void reject();
     void keyReleaseEvent(QKeyEvent *e);
 
 private slots:
-    void showFullScreen();
     void processArrow(int key);
 
 private:
+    QScrollArea *scroll; /**< The scrollable area containing the image */
     ImageWidget *display; /**< The widget which displays the image */
     QPixmap pm; /**< The image currently being shown */
     QDialogButtonBox *okCancelRow; /**< The row of dialog buttons */

--- a/src/portabase.cpp
+++ b/src/portabase.cpp
@@ -1475,7 +1475,11 @@ void PortaBase::setRowSelected(bool y)
 void PortaBase::toggleFullscreen()
 {
     if (isFullScreen()) {
+#if defined(MOBILE)
+        showMaximized();
+#else
         showNormal();
+#endif
         QAction *action = qobject_cast<QAction *>(sender());
         action->setText(ma->menuText(MenuActions::Fullscreen));
         QString toolTip = ma->toolTipText(MenuActions::Fullscreen);


### PR DESCRIPTION
PortaBase was still using a hack for fullscreen image display that predated the addition of proper fullscreen support in Qt, and at least with Qt 5 it sometimes resulted in odd failures to return to normal display mode.  Switched over to the same approach used for the main window's fullscreen mode.