### PR TITLE
More reliable column resizing, fix image editor on Android

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,16 @@
+2017-03-28  JMB  Fix image selector/editor on Android
+
+    The image selection/editing dialog hadn't been properly tested on
+    Android yet; made a couple of fixes to make it work correctly.
+
+2017-03-27  JMB  More reliable column resizing
+
+    At least on Android, setting the width of a column from the column
+    statistics dialog triggered a cascade of events which could sometimes
+    inadvertently change the widths of other columns also.  Disabled a signal
+    hander while applying changes from the dialog to prevent this from
+    happening.
+
 2017-03-24  JMB  Better slideshow mode
 
     Switched over slideshows to use the image viewer dialog which was

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,6 @@ Maemo (Diablo and Fremantle).
 
 The main features PortaBase currently has are:
 
-- One data table per file
 - String, Integer, Decimal, Boolean, Note (multi-line text), Date, Time,
   Calculation, Sequence, Image, and Enum column types
 - Add, edit, and delete rows of data
@@ -29,21 +28,23 @@ The main features PortaBase currently has are:
 - Filter the displayed rows using sets of conditions
 - Sort the rows by any combination of columns, each in ascending or descending
   order
-- Optional page navigation buttons, with a custom number of rows per page
 - Add, delete, rearrange, and rename columns at any time
 - Specify default values for columns
 - View summary statistics for columns (total, average, min, max, etc.)
+- Data file encryption
+- Slideshows of the images in a column matching the current filter
+- Simple calculator widget for entering numeric data
+- Printing of the currently displayed data (except on mobile devices)
+- Optional fullscreen mode
 - Import data from CSV, XML, and MobileDB files
 - Export data to CSV, HTML, and XML files
 - Command-line format conversions (to and from XML, to and from CSV,
   from MobileDB, to HTML)
-- Data file encryption
 - Unicode support for text columns, and UI translations for 8 different
   languages
 - Pick any available font to use throughout the application (except on
   Mac OS X)
 - User-specified alternating row background colors (except on Fremantle)
-- Simple calculator widget for entering numeric data
 
 See the application's help dialog for more information on features and usage.
 

--- a/src/image/imageutils.cpp
+++ b/src/image/imageutils.cpp
@@ -87,7 +87,7 @@ QImage ImageUtils::readImage(QImageReader *reader)
 #else
     QSize targetSize(800, 600);
 #endif
-    QSize displaySize(reader->size());
+    QSize displaySize(reader->scaledSize());
     if (displaySize.width() > targetSize.width() ||
             displaySize.height() > targetSize.height()) {
         displaySize.scale(targetSize, Qt::KeepAspectRatio);

--- a/src/image/imageviewer.cpp
+++ b/src/image/imageviewer.cpp
@@ -25,6 +25,10 @@
 #include "../qqutil/qqfactory.h"
 #include "../view.h"
 
+#if defined(Q_OS_ANDROID)
+#include "../qqutil/actionbar.h"
+#endif
+
 #if defined(Q_WS_HILDON) || defined(Q_WS_MAEMO_5)
 #include <QtDBus>
 #include <mce/mode-names.h>
@@ -156,6 +160,9 @@ void ImageViewer::showFullScreen()
 #if !defined(MOBILE)
     okCancelRow->hide();
 #endif
+#if defined(Q_OS_ANDROID)
+    actionBar->hide();
+#endif
     QPalette scrollPalette(palette());
     scrollPalette.setColor(QPalette::Window, Qt::black);
     setPalette(scrollPalette);
@@ -174,6 +181,9 @@ void ImageViewer::showNormal()
     connect(display, SIGNAL(clicked()), this, SLOT(showFullScreen()));
     setPalette(parentWidget()->palette());
     scroll->setFrameShape(QFrame::StyledPanel);
+#if defined(Q_OS_ANDROID)
+    actionBar->show();
+#endif
 #if defined(MOBILE)
     PBDialog::showFullScreen();
 #else
@@ -310,4 +320,17 @@ void ImageViewer::keepScreenOn()
                                        MCE_REQUEST_IF,
                                        MCE_PREVENT_BLANK_REQ));
 #endif
+}
+
+/**
+ * Respond to the screen orientation or size changing.  Resizes the displayed
+ * image if appropriate.
+ *
+ * @param geometry The new screen dimensions (in pixels)
+ */
+void ImageViewer::screenGeometryChanged(const QRect &geometry)
+{
+    int rowId = currentView->getId(rowIndex);
+    setImage(currentView->getImage(rowId, colIndex));
+    PBDialog::screenGeometryChanged(geometry);
 }

--- a/src/image/imageviewer.h
+++ b/src/image/imageviewer.h
@@ -52,6 +52,9 @@ protected:
     void reject();
     void keyReleaseEvent(QKeyEvent *e);
 
+protected slots:
+    void screenGeometryChanged(const QRect &geometry);
+
 private slots:
     void keepScreenOn();
     void nextImage();

--- a/src/qqutil/qqdialog.h
+++ b/src/qqutil/qqdialog.h
@@ -56,8 +56,8 @@ protected:
     ActionBar *actionBar; /**< The Android action bar at the top of the screen */
 #endif
 
-private slots:
-    void screenGeometryChanged(const QRect &geometry);
+protected slots:
+    virtual void screenGeometryChanged(const QRect &geometry);
 
 private:
     QString dialogClassName; /**< The class name of the subclass instance */

--- a/src/viewdisplay.cpp
+++ b/src/viewdisplay.cpp
@@ -472,10 +472,16 @@ void ViewDisplay::matchNewView(View *view)
     int pixelsPerDP = 1;
 #endif
     int count = view->columnCount();
+    // Avoid accidentally changing other columns in the process
+    QHeaderView *header = table->header();
+    disconnect(header, SIGNAL(sectionResized(int, int, int)),
+               this, SLOT(columnResized(int, int, int)));
     for (int i = 0; i < count; i++) {
         int pixelWidth = (int)(view->getColWidth(i) * pixelsPerDP);
         table->setColumnWidth(i, pixelWidth);
     }
+    connect(header, SIGNAL(sectionResized(int, int, int)),
+            this, SLOT(columnResized(int, int, int)));
     table->setColumnWidth(count, 0);
     rowsPerPage->setValue(view->getRowsPerPage());
 }


### PR DESCRIPTION
At least on Android, setting the width of a column from the column statistics dialog triggered a cascade of events which could sometimes inadvertently change the widths of other columns also.  Disabled a signal hander while applying changes from the dialog to prevent this from happening.

Also, the image selection/editing dialog hadn't been properly tested on Android yet; made a couple of fixes to make it work correctly.