### PR TITLE
Better default row color choice, fix edit field cursor positioning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,11 @@
-2017-03-29  JMB  Add help action to Android
+2017-03-29  JMB  Add help action to Android, visual fixes
 
     Added a "Help" action to Android which points to the online help files
     in the appropriate language.
+
+    Changed the default Android alternate row background color to one which
+    is easier to distinguish, and removed some padding on dynamic-height
+    text inputs which was causing the cursor to be mis-positioned.
 
 2017-03-28  JMB  Fix image selector/editor on Android
 

--- a/src/dynamicedit.cpp
+++ b/src/dynamicedit.cpp
@@ -39,7 +39,8 @@ DynamicEdit::DynamicEdit(QWidget *parent)
     Factory::configureScrollArea(this);
 #if defined(Q_OS_ANDROID)
     int pixels = Factory::dpToPixels(6);
-    setStyleSheet(QString("QTextEdit {padding-left:%1px; padding-top:%1px; padding-bottom:%1px; padding-right:%1px}").arg(pixels));
+    // Can't use left padding without making the cursor misaligned
+    setStyleSheet(QString("QTextEdit {padding-top:%1px; padding-bottom:%1px; padding-right:%1px}").arg(pixels));
     setTextInteractionFlags(textInteractionFlags() | Qt::TextSelectableByMouse);
 #endif
 }

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -44,7 +44,12 @@ void Factory::updatePreferences(QSettings *settings)
     QString defaultBase = qApp->palette("QAbstractItemView").color(QPalette::Base).name();
     QString color = settings->value("EvenRows", defaultBase).toString();
     evenRowColor = QColor(color);
+#if defined(Q_OS_ANDROID)
+    // The theme default alternate color is way too close to white
+    QString defaultAlternateBase("lightblue");
+#else
     QString defaultAlternateBase = qApp->palette("QAbstractItemView").color(QPalette::AlternateBase).name();
+#endif
     color = settings->value("OddRows", defaultAlternateBase).toString();
     oddRowColor = QColor(color);
     settings->endGroup();


### PR DESCRIPTION
Changed the default Android alternate row background color to a different one (light blue) which is easier to distinguish, and removed some padding on dynamic-height text inputs which was causing the cursor to be mis-positioned.