### PR TITLE
Update the help file translation templates

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,14 @@
+2017-04-02  JMB  Release preparation and assorted bugfixes
+
+    * Added the latest Italian translation updates.
+    * Fixed a rather long-standing bug where the view editor failed to save
+      which columns are to be included when first creating a new view.
+    * Removed the top padding for dynamic-height text fields on Android to
+      fully fix the cursor alignment problem.
+    * Fixed the spacing on the popup menu for the column statistics dialog's
+      column listing.
+    * Updated the help file translation templates
+
 2017-03-30  JMB  Update UI translations, fix them on Android, new help theme
 
     Updated the UI translation files, and fixed a configuration bug which was

--- a/resources/help/command_line.txt
+++ b/resources/help/command_line.txt
@@ -48,4 +48,4 @@ There's also one additional option for ``tocsv``:
 
 -l line_ending  "crlf" to use Windows-style carriage return + newline, default is UNIX/Mac-style (newline only)
 
-For more information about the PortaBase XML format and tools for doing useful things with it, see the PortaBase homepage (http://portabase.sourceforge.net).
+For more information about the PortaBase XML format and tools for doing useful things with it, see the PortaBase homepage (http://portabase.org).

--- a/resources/help/encryption.txt
+++ b/resources/help/encryption.txt
@@ -15,4 +15,4 @@ PortaBase data files can be encrypted in order to protect sensitive information 
 
 For security and implementation reasons, the entire content of encrypted files must be held in memory at once; thus encrypted files cannot scale to large sizes as well as non-encrypted files.  Files of a few hundred or a few thousand rows should still perform well, but files containing many thousands of rows of data probably won't (at least on Maemo; desktop computers with lots of memory can handle quite large encrypted files).
 
-For more information about encryption in PortaBase (including details on the algorithms used), see the PortaBase homepage (http://portabase.sourceforge.net).
+For more information about encryption in PortaBase (including details on the algorithms used), see the PortaBase homepage (http://portabase.org).

--- a/resources/help/translations/templates/calculation_editor.pot
+++ b/resources/help/translations/templates/calculation_editor.pot
@@ -1,13 +1,13 @@
 # Messages from calculation_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/column_statistics.pot
+++ b/resources/help/translations/templates/column_statistics.pot
@@ -1,13 +1,13 @@
 # Messages from column_statistics.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/columns_editor.pot
+++ b/resources/help/translations/templates/columns_editor.pot
@@ -1,13 +1,13 @@
 # Messages from columns_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/command_line.pot
+++ b/resources/help/translations/templates/command_line.pot
@@ -1,13 +1,13 @@
 # Messages from command_line.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -122,7 +122,39 @@ msgid "Apply the named filter before exporting."
 msgstr ""
 
 #: ../../command_line.txt:37
+msgid "The following options can be used with either ``fromcsv`` or ``tocsv``:"
+msgstr ""
+
+#: ../../command_line.txt:39
+msgid "There is or should be a row of column headers"
+msgstr ""
+
+#: ../../command_line.txt:40
+msgid "The field delimiter character (typically 'tab' if not using the default ',')"
+msgstr ""
+
+#: ../../command_line.txt:41
+msgid "Parse or write the CSV file using the specified text encoding (the default is UTF-8)"
+msgstr ""
+
+#: ../../command_line.txt:43
+msgid "There's one additional option for ``fromcsv``:"
+msgstr ""
+
+#: ../../command_line.txt:45
+msgid "Automatically add new enum values encountered"
+msgstr ""
+
+#: ../../command_line.txt:47
+msgid "There's also one additional option for ``tocsv``:"
+msgstr ""
+
+#: ../../command_line.txt:49
+msgid "\"crlf\" to use Windows-style carriage return + newline, default is UNIX/Mac-style (newline only)"
+msgstr ""
+
+#: ../../command_line.txt:51
 # 0af6523a1160474ba4a62dd8d3ffb4f4
-msgid "For more information about the PortaBase XML format and tools for doing useful things with it, see the PortaBase homepage (http://portabase.sourceforge.net)."
+msgid "For more information about the PortaBase XML format and tools for doing useful things with it, see the PortaBase homepage (http://portabase.org)."
 msgstr ""
 

--- a/resources/help/translations/templates/data_viewer.pot
+++ b/resources/help/translations/templates/data_viewer.pot
@@ -1,13 +1,13 @@
 # Messages from data_viewer.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/encryption.pot
+++ b/resources/help/translations/templates/encryption.pot
@@ -1,13 +1,13 @@
 # Messages from encryption.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -53,6 +53,6 @@ msgstr ""
 
 #: ../../encryption.txt:18
 # e3957606668e40a5b52edfcff6495d6d
-msgid "For more information about encryption in PortaBase (including details on the algorithms used), see the PortaBase homepage (http://portabase.sourceforge.net)."
+msgid "For more information about encryption in PortaBase (including details on the algorithms used), see the PortaBase homepage (http://portabase.org)."
 msgstr ""
 

--- a/resources/help/translations/templates/enum_editor.pot
+++ b/resources/help/translations/templates/enum_editor.pot
@@ -1,13 +1,13 @@
 # Messages from enum_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/enum_manager.pot
+++ b/resources/help/translations/templates/enum_manager.pot
@@ -1,13 +1,13 @@
 # Messages from enum_manager.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/export.pot
+++ b/resources/help/translations/templates/export.pot
@@ -1,13 +1,13 @@
 # Messages from export.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/file_selector.pot
+++ b/resources/help/translations/templates/file_selector.pot
@@ -1,13 +1,13 @@
 # Messages from file_selector.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/filter_editor.pot
+++ b/resources/help/translations/templates/filter_editor.pot
@@ -1,13 +1,13 @@
 # Messages from filter_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/image_editor.pot
+++ b/resources/help/translations/templates/image_editor.pot
@@ -1,13 +1,13 @@
 # Messages from image_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -70,9 +70,3 @@ msgstr ""
 # b94f400f3398469abc82d28724bdebee
 msgid "Click \"OK\"/\"Done\" to store the image as it is shown, or cancel out of the dialog to leave the field unchanged."
 msgstr ""
-
-#: ../../image_editor.txt:22
-# a2edd321360d4e79a296b5fdaa25bbf6
-msgid "Because memory was limited on the Zaurus PDAs for which PortaBase was originally developed, very large pictures will be rejected.  JPEG images larger than 6400 x 4800 pixels cannot be imported, and ones larger than 800 x 600 will be shrunk to at most that size.  Similarly, PNG images larger than 800 x 600 cannot be imported.  These limitations will be removed in a future version of PortaBase, since it is no longer being developed for the Zaurus."
-msgstr ""
-

--- a/resources/help/translations/templates/image_viewer.pot
+++ b/resources/help/translations/templates/image_viewer.pot
@@ -1,13 +1,13 @@
 # Messages from image_viewer.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/import.pot
+++ b/resources/help/translations/templates/import.pot
@@ -1,13 +1,13 @@
 # Messages from import.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/index.pot
+++ b/resources/help/translations/templates/index.pot
@@ -1,13 +1,13 @@
 # Messages from index.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/introduction.pot
+++ b/resources/help/translations/templates/introduction.pot
@@ -1,13 +1,13 @@
 # Messages from introduction.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/note_editor.pot
+++ b/resources/help/translations/templates/note_editor.pot
@@ -1,13 +1,13 @@
 # Messages from note_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/preferences.pot
+++ b/resources/help/translations/templates/preferences.pot
@@ -1,13 +1,13 @@
 # Messages from preferences.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -183,7 +183,7 @@ msgstr ""
 
 #: ../../preferences.txt:71
 # 5402968d97534040b21bbfd56d5f5b88
-msgid "The \"Row Colors\" section contains two buttons which allow you to choose the colors which will be used for the backgrounds of rows in the data viewer, columns editor, view editor, and sorting editor.  Each button shows one of the current colors; clicking on one launches a color selection dialog in which you can pick a different color to use."
+msgid "The \"Row Colors\" section contains two buttons which allow you to choose the colors which will be used for the backgrounds of rows in the data viewer, columns editor, view editor, and sorting editor.  The color selected by the second button is also used as the alternate row color in the row viewer.  Each button shows one of the current colors; clicking on one launches a color selection dialog in which you can pick a different color to use.  There is also a \"Reset\" button to revert to the system's default colors."
 msgstr ""
 
 #: ../../preferences.txt:73

--- a/resources/help/translations/templates/row_editor.pot
+++ b/resources/help/translations/templates/row_editor.pot
@@ -1,13 +1,13 @@
 # Messages from row_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/row_viewer.pot
+++ b/resources/help/translations/templates/row_viewer.pot
@@ -1,13 +1,13 @@
 # Messages from row_viewer.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/sorting_editor.pot
+++ b/resources/help/translations/templates/sorting_editor.pot
@@ -1,13 +1,13 @@
 # Messages from sorting_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/sphinx.pot
+++ b/resources/help/translations/templates/sphinx.pot
@@ -1,196 +1,240 @@
 # Translations template for Sphinx.
-# Copyright (C) 2011 ORGANIZATION
+# Copyright (C) 2016 ORGANIZATION
 # This file is distributed under the same license as the Sphinx project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2011.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Sphinx 1.1pre/9523af9ba9aa+\n"
+"Project-Id-Version: Sphinx 1.5b1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2011-09-21 10:06+0200\n"
+"POT-Creation-Date: 2016-11-06 22:40+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 0.9.6\n"
+"Generated-By: Babel 2.3.4\n"
 
-#: sphinx/config.py:81
+#: sphinx/config.py:109
 #, python-format
-msgid "%s %s documentation"
+msgid "Section %s"
 msgstr ""
 
-#: sphinx/environment.py:119 sphinx/writers/latex.py:190
-#: sphinx/writers/manpage.py:67 sphinx/writers/texinfo.py:203
+#: sphinx/config.py:110
 #, python-format
-msgid "%B %d, %Y"
+msgid "Fig. %s"
 msgstr ""
 
-#: sphinx/environment.py:1625
+#: sphinx/config.py:111
 #, python-format
-msgid "see %s"
+msgid "Table %s"
 msgstr ""
 
-#: sphinx/environment.py:1628
+#: sphinx/config.py:112
 #, python-format
-msgid "see also %s"
+msgid "Listing %s"
 msgstr ""
 
-#: sphinx/roles.py:175
+#: sphinx/roles.py:187
 #, python-format
 msgid "Python Enhancement Proposals; PEP %s"
 msgstr ""
 
-#: sphinx/builders/changes.py:73
+#: sphinx/builders/changes.py:75
 msgid "Builtins"
 msgstr ""
 
-#: sphinx/builders/changes.py:75
+#: sphinx/builders/changes.py:77
 msgid "Module level"
 msgstr ""
 
-#: sphinx/builders/html.py:274
+#: sphinx/builders/html.py:294 sphinx/transforms/__init__.py:46
+#: sphinx/writers/latex.py:393 sphinx/writers/manpage.py:100
+#: sphinx/writers/texinfo.py:221
 #, python-format
 msgid "%b %d, %Y"
 msgstr ""
 
-#: sphinx/builders/html.py:293 sphinx/themes/basic/defindex.html:30
+#: sphinx/builders/html.py:315 sphinx/themes/basic/defindex.html:30
 msgid "General Index"
 msgstr ""
 
-#: sphinx/builders/html.py:293
+#: sphinx/builders/html.py:315
 msgid "index"
 msgstr ""
 
-#: sphinx/builders/html.py:353
+#: sphinx/builders/html.py:377
 msgid "next"
 msgstr ""
 
-#: sphinx/builders/html.py:362
+#: sphinx/builders/html.py:386
 msgid "previous"
 msgstr ""
 
-#: sphinx/builders/latex.py:141 sphinx/builders/texinfo.py:196
+#: sphinx/builders/html.py:1222
+#, python-format
+msgid "%s %s documentation"
+msgstr ""
+
+#: sphinx/builders/latex.py:177 sphinx/builders/texinfo.py:199
 msgid " (in "
 msgstr ""
 
-#: sphinx/directives/other.py:136
+#: sphinx/directives/code.py:140 sphinx/directives/code.py:370
+#, python-format
+msgid "Invalid caption: %s"
+msgstr ""
+
+#: sphinx/directives/other.py:149
 msgid "Section author: "
 msgstr ""
 
-#: sphinx/directives/other.py:138
+#: sphinx/directives/other.py:151
 msgid "Module author: "
 msgstr ""
 
-#: sphinx/directives/other.py:140
+#: sphinx/directives/other.py:153
 msgid "Code author: "
 msgstr ""
 
-#: sphinx/directives/other.py:142
+#: sphinx/directives/other.py:155
 msgid "Author: "
 msgstr ""
 
-#: sphinx/directives/other.py:215
-msgid "See also"
-msgstr ""
-
-#: sphinx/domains/__init__.py:244
+#: sphinx/domains/__init__.py:277
 #, python-format
 msgid "%s %s"
 msgstr ""
 
-#: sphinx/domains/c.py:51 sphinx/domains/python.py:95
+#: sphinx/domains/c.py:58 sphinx/domains/cpp.py:4051
+#: sphinx/domains/python.py:149
 msgid "Parameters"
 msgstr ""
 
-#: sphinx/domains/c.py:54 sphinx/domains/javascript.py:128
-#: sphinx/domains/python.py:107
+#: sphinx/domains/c.py:61 sphinx/domains/cpp.py:4060
+#: sphinx/domains/javascript.py:128 sphinx/domains/python.py:161
 msgid "Returns"
 msgstr ""
 
-#: sphinx/domains/c.py:56 sphinx/domains/python.py:109
+#: sphinx/domains/c.py:63 sphinx/domains/javascript.py:130
+#: sphinx/domains/python.py:163
 msgid "Return type"
 msgstr ""
 
-#: sphinx/domains/c.py:141
+#: sphinx/domains/c.py:177
 #, python-format
 msgid "%s (C function)"
 msgstr ""
 
-#: sphinx/domains/c.py:143
+#: sphinx/domains/c.py:179
 #, python-format
 msgid "%s (C member)"
 msgstr ""
 
-#: sphinx/domains/c.py:145
+#: sphinx/domains/c.py:181
 #, python-format
 msgid "%s (C macro)"
 msgstr ""
 
-#: sphinx/domains/c.py:147
+#: sphinx/domains/c.py:183
 #, python-format
 msgid "%s (C type)"
 msgstr ""
 
-#: sphinx/domains/c.py:149
+#: sphinx/domains/c.py:185
 #, python-format
 msgid "%s (C variable)"
 msgstr ""
 
-#: sphinx/domains/c.py:204 sphinx/domains/cpp.py:1060
-#: sphinx/domains/javascript.py:162 sphinx/domains/python.py:559
+#: sphinx/domains/c.py:242 sphinx/domains/cpp.py:4418
+#: sphinx/domains/javascript.py:164 sphinx/domains/python.py:614
 msgid "function"
 msgstr ""
 
-#: sphinx/domains/c.py:205 sphinx/domains/cpp.py:1061
+#: sphinx/domains/c.py:243 sphinx/domains/cpp.py:4419
 msgid "member"
 msgstr ""
 
-#: sphinx/domains/c.py:206
+#: sphinx/domains/c.py:244
 msgid "macro"
 msgstr ""
 
-#: sphinx/domains/c.py:207 sphinx/domains/cpp.py:1062
+#: sphinx/domains/c.py:245 sphinx/domains/cpp.py:4420
 msgid "type"
 msgstr ""
 
-#: sphinx/domains/c.py:208
+#: sphinx/domains/c.py:246
 msgid "variable"
 msgstr ""
 
-#: sphinx/domains/cpp.py:904
-#, python-format
-msgid "%s (C++ class)"
+#: sphinx/domains/cpp.py:4054
+msgid "Template Parameters"
 msgstr ""
 
-#: sphinx/domains/cpp.py:919
+#: sphinx/domains/cpp.py:4057 sphinx/domains/javascript.py:125
+msgid "Throws"
+msgstr ""
+
+#: sphinx/domains/cpp.py:4205
 #, python-format
 msgid "%s (C++ type)"
 msgstr ""
 
-#: sphinx/domains/cpp.py:938
+#: sphinx/domains/cpp.py:4216
+#, python-format
+msgid "%s (C++ concept)"
+msgstr ""
+
+#: sphinx/domains/cpp.py:4227
 #, python-format
 msgid "%s (C++ member)"
 msgstr ""
 
-#: sphinx/domains/cpp.py:990
+#: sphinx/domains/cpp.py:4238
 #, python-format
 msgid "%s (C++ function)"
 msgstr ""
 
-#: sphinx/domains/cpp.py:1059 sphinx/domains/javascript.py:163
-#: sphinx/domains/python.py:561
+#: sphinx/domains/cpp.py:4249
+#, python-format
+msgid "%s (C++ class)"
+msgstr ""
+
+#: sphinx/domains/cpp.py:4260
+#, python-format
+msgid "%s (C++ enum)"
+msgstr ""
+
+#: sphinx/domains/cpp.py:4281
+#, python-format
+msgid "%s (C++ enumerator)"
+msgstr ""
+
+#: sphinx/domains/cpp.py:4417 sphinx/domains/javascript.py:165
+#: sphinx/domains/python.py:616
 msgid "class"
 msgstr ""
 
-#: sphinx/domains/javascript.py:106 sphinx/domains/python.py:254
+#: sphinx/domains/cpp.py:4421
+msgid "concept"
+msgstr ""
+
+#: sphinx/domains/cpp.py:4422
+msgid "enum"
+msgstr ""
+
+#: sphinx/domains/cpp.py:4423
+msgid "enumerator"
+msgstr ""
+
+#: sphinx/domains/javascript.py:106 sphinx/domains/python.py:307
 #, python-format
 msgid "%s() (built-in function)"
 msgstr ""
 
-#: sphinx/domains/javascript.py:107 sphinx/domains/python.py:318
+#: sphinx/domains/javascript.py:107 sphinx/domains/python.py:371
 #, python-format
 msgid "%s() (%s method)"
 msgstr ""
@@ -205,7 +249,7 @@ msgstr ""
 msgid "%s (global variable or constant)"
 msgstr ""
 
-#: sphinx/domains/javascript.py:113 sphinx/domains/python.py:356
+#: sphinx/domains/javascript.py:113 sphinx/domains/python.py:409
 #, python-format
 msgid "%s (%s attribute)"
 msgstr ""
@@ -214,120 +258,116 @@ msgstr ""
 msgid "Arguments"
 msgstr ""
 
-#: sphinx/domains/javascript.py:125
-msgid "Throws"
-msgstr ""
-
-#: sphinx/domains/javascript.py:164 sphinx/domains/python.py:560
+#: sphinx/domains/javascript.py:166 sphinx/domains/python.py:615
 msgid "data"
 msgstr ""
 
-#: sphinx/domains/javascript.py:165 sphinx/domains/python.py:566
+#: sphinx/domains/javascript.py:167 sphinx/domains/python.py:621
 msgid "attribute"
 msgstr ""
 
-#: sphinx/domains/python.py:100
+#: sphinx/domains/python.py:154
 msgid "Variables"
 msgstr ""
 
-#: sphinx/domains/python.py:104
+#: sphinx/domains/python.py:158
 msgid "Raises"
 msgstr ""
 
-#: sphinx/domains/python.py:255 sphinx/domains/python.py:312
-#: sphinx/domains/python.py:324 sphinx/domains/python.py:337
+#: sphinx/domains/python.py:308 sphinx/domains/python.py:365
+#: sphinx/domains/python.py:377 sphinx/domains/python.py:390
 #, python-format
 msgid "%s() (in module %s)"
 msgstr ""
 
-#: sphinx/domains/python.py:258
+#: sphinx/domains/python.py:311
 #, python-format
 msgid "%s (built-in variable)"
 msgstr ""
 
-#: sphinx/domains/python.py:259 sphinx/domains/python.py:350
+#: sphinx/domains/python.py:312 sphinx/domains/python.py:403
 #, python-format
 msgid "%s (in module %s)"
 msgstr ""
 
-#: sphinx/domains/python.py:275
+#: sphinx/domains/python.py:328
 #, python-format
 msgid "%s (built-in class)"
 msgstr ""
 
-#: sphinx/domains/python.py:276
+#: sphinx/domains/python.py:329
 #, python-format
 msgid "%s (class in %s)"
 msgstr ""
 
-#: sphinx/domains/python.py:316
+#: sphinx/domains/python.py:369
 #, python-format
 msgid "%s() (%s.%s method)"
 msgstr ""
 
-#: sphinx/domains/python.py:328
+#: sphinx/domains/python.py:381
 #, python-format
 msgid "%s() (%s.%s static method)"
 msgstr ""
 
-#: sphinx/domains/python.py:331
+#: sphinx/domains/python.py:384
 #, python-format
 msgid "%s() (%s static method)"
 msgstr ""
 
-#: sphinx/domains/python.py:341
+#: sphinx/domains/python.py:394
 #, python-format
 msgid "%s() (%s.%s class method)"
 msgstr ""
 
-#: sphinx/domains/python.py:344
+#: sphinx/domains/python.py:397
 #, python-format
 msgid "%s() (%s class method)"
 msgstr ""
 
-#: sphinx/domains/python.py:354
+#: sphinx/domains/python.py:407
 #, python-format
 msgid "%s (%s.%s attribute)"
 msgstr ""
 
-#: sphinx/domains/python.py:434
+#: sphinx/domains/python.py:488
 #, python-format
 msgid "%s (module)"
 msgstr ""
 
-#: sphinx/domains/python.py:491
+#: sphinx/domains/python.py:545
 msgid "Python Module Index"
 msgstr ""
 
-#: sphinx/domains/python.py:492
+#: sphinx/domains/python.py:546
 msgid "modules"
 msgstr ""
 
-#: sphinx/domains/python.py:537
+#: sphinx/domains/python.py:592
 msgid "Deprecated"
 msgstr ""
 
-#: sphinx/domains/python.py:562 sphinx/locale/__init__.py:179
+#: sphinx/domains/python.py:617 sphinx/locale/__init__.py:183
 msgid "exception"
 msgstr ""
 
-#: sphinx/domains/python.py:563
+#: sphinx/domains/python.py:618
 msgid "method"
 msgstr ""
 
-#: sphinx/domains/python.py:564
+#: sphinx/domains/python.py:619
 msgid "class method"
 msgstr ""
 
-#: sphinx/domains/python.py:565
+#: sphinx/domains/python.py:620
 msgid "static method"
 msgstr ""
 
-#: sphinx/domains/python.py:567 sphinx/locale/__init__.py:175
+#: sphinx/domains/python.py:622 sphinx/locale/__init__.py:179
 msgid "module"
 msgstr ""
 
-#: sphinx/domains/python.py:695
+#: sphinx/domains/python.py:787
 msgid " (deprecated)"
 msgstr ""
 
@@ -349,200 +389,255 @@ msgstr ""
 msgid "role"
 msgstr ""
 
-#: sphinx/domains/std.py:70 sphinx/domains/std.py:86
+#: sphinx/domains/std.py:72 sphinx/domains/std.py:88
 #, python-format
 msgid "environment variable; %s"
 msgstr ""
 
-#: sphinx/domains/std.py:162
+#: sphinx/domains/std.py:186
 #, python-format
 msgid "%scommand line option; %s"
 msgstr ""
 
-#: sphinx/domains/std.py:393
+#: sphinx/domains/std.py:434
 msgid "glossary term"
 msgstr ""
 
-#: sphinx/domains/std.py:394
+#: sphinx/domains/std.py:435
 msgid "grammar token"
 msgstr ""
 
-#: sphinx/domains/std.py:395
+#: sphinx/domains/std.py:436
 msgid "reference label"
 msgstr ""
 
-#: sphinx/domains/std.py:396
+#: sphinx/domains/std.py:438
 msgid "environment variable"
 msgstr ""
 
-#: sphinx/domains/std.py:397
+#: sphinx/domains/std.py:439
 msgid "program option"
 msgstr ""
 
-#: sphinx/domains/std.py:427 sphinx/themes/basic/genindex-single.html:32
+#: sphinx/domains/std.py:473 sphinx/themes/basic/genindex-single.html:30
+#: sphinx/themes/basic/genindex-single.html:55
 #: sphinx/themes/basic/genindex-split.html:11
 #: sphinx/themes/basic/genindex-split.html:14
-#: sphinx/themes/basic/genindex.html:32 sphinx/themes/basic/genindex.html:35
-#: sphinx/themes/basic/genindex.html:68 sphinx/themes/basic/layout.html:134
-#: sphinx/writers/latex.py:179 sphinx/writers/texinfo.py:456
+#: sphinx/themes/basic/genindex.html:30 sphinx/themes/basic/genindex.html:33
+#: sphinx/themes/basic/genindex.html:66 sphinx/themes/basic/layout.html:135
+#: sphinx/writers/latex.py:381 sphinx/writers/texinfo.py:480
 msgid "Index"
 msgstr ""
 
-#: sphinx/domains/std.py:428
+#: sphinx/domains/std.py:474
 msgid "Module Index"
 msgstr ""
 
-#: sphinx/domains/std.py:429 sphinx/themes/basic/defindex.html:25
+#: sphinx/domains/std.py:475 sphinx/themes/basic/defindex.html:25
 msgid "Search Page"
 msgstr ""
 
-#: sphinx/ext/autodoc.py:1002
+#: sphinx/environment/managers/indexentries.py:104
 #, python-format
-msgid "   Bases: %s"
+msgid "see %s"
 msgstr ""
 
-#: sphinx/ext/autodoc.py:1038
+#: sphinx/environment/managers/indexentries.py:108
+#, python-format
+msgid "see also %s"
+msgstr ""
+
+#: sphinx/environment/managers/indexentries.py:168
+msgid "Symbols"
+msgstr ""
+
+#: sphinx/ext/autodoc.py:1297
+#, python-format
+msgid "Bases: %s"
+msgstr ""
+
+#: sphinx/ext/autodoc.py:1350
 #, python-format
 msgid "alias of :class:`%s`"
 msgstr ""
 
-#: sphinx/ext/todo.py:41
-msgid "Todo"
-msgstr ""
-
-#: sphinx/ext/todo.py:109
+#: sphinx/ext/graphviz.py:331 sphinx/ext/graphviz.py:340
 #, python-format
-msgid "(The <<original entry>> is located in  %s, line %d.)"
+msgid "[graph: %s]"
 msgstr ""
 
-#: sphinx/ext/todo.py:117
-msgid "original entry"
+#: sphinx/ext/graphviz.py:333 sphinx/ext/graphviz.py:342
+msgid "[graph]"
 msgstr ""
 
-#: sphinx/ext/viewcode.py:70
+#: sphinx/ext/imgmath.py:258 sphinx/ext/jsmath.py:39 sphinx/ext/mathjax.py:40
+msgid "Permalink to this equation"
+msgstr ""
+
+#: sphinx/ext/intersphinx.py:337
+#, python-format
+msgid "(in %s v%s)"
+msgstr ""
+
+#: sphinx/ext/linkcode.py:69 sphinx/ext/viewcode.py:103
 msgid "[source]"
 msgstr ""
 
-#: sphinx/ext/viewcode.py:117
+#: sphinx/ext/mathbase.py:92
+#, python-format
+msgid "duplicate label of equation %s, other instance in %s"
+msgstr ""
+
+#: sphinx/ext/todo.py:56
+msgid "Todo"
+msgstr ""
+
+#: sphinx/ext/todo.py:134
+msgid "<<original entry>>"
+msgstr ""
+
+#: sphinx/ext/todo.py:137
+#, python-format
+msgid "(The <<original entry>> is located in %s, line %d.)"
+msgstr ""
+
+#: sphinx/ext/todo.py:146
+msgid "original entry"
+msgstr ""
+
+#: sphinx/ext/viewcode.py:166
 msgid "[docs]"
 msgstr ""
 
-#: sphinx/ext/viewcode.py:131
+#: sphinx/ext/viewcode.py:180
 msgid "Module code"
 msgstr ""
 
-#: sphinx/ext/viewcode.py:137
+#: sphinx/ext/viewcode.py:186
 #, python-format
 msgid "<h1>Source code for %s</h1>"
 msgstr ""
 
-#: sphinx/ext/viewcode.py:164
+#: sphinx/ext/viewcode.py:212
 msgid "Overview: module code"
 msgstr ""
 
-#: sphinx/ext/viewcode.py:165
+#: sphinx/ext/viewcode.py:213
 msgid "<h1>All modules for which code is available</h1>"
 msgstr ""
 
-#: sphinx/locale/__init__.py:155
-msgid "Attention"
-msgstr ""
-
-#: sphinx/locale/__init__.py:156
-msgid "Caution"
-msgstr ""
-
-#: sphinx/locale/__init__.py:157
-msgid "Danger"
-msgstr ""
-
-#: sphinx/locale/__init__.py:158
-msgid "Error"
+#: sphinx/ext/napoleon/__init__.py:313
+msgid "Keyword Arguments"
 msgstr ""
 
 #: sphinx/locale/__init__.py:159
-msgid "Hint"
+msgid "Attention"
 msgstr ""
 
 #: sphinx/locale/__init__.py:160
-msgid "Important"
+msgid "Caution"
 msgstr ""
 
 #: sphinx/locale/__init__.py:161
-msgid "Note"
+msgid "Danger"
 msgstr ""
 
 #: sphinx/locale/__init__.py:162
-msgid "See Also"
+msgid "Error"
 msgstr ""
 
 #: sphinx/locale/__init__.py:163
-msgid "Tip"
+msgid "Hint"
 msgstr ""
 
 #: sphinx/locale/__init__.py:164
-msgid "Warning"
+msgid "Important"
+msgstr ""
+
+#: sphinx/locale/__init__.py:165
+msgid "Note"
+msgstr ""
+
+#: sphinx/locale/__init__.py:166
+msgid "See also"
+msgstr ""
+
+#: sphinx/locale/__init__.py:167
+msgid "Tip"
 msgstr ""
 
 #: sphinx/locale/__init__.py:168
+msgid "Warning"
+msgstr ""
+
+#: sphinx/locale/__init__.py:172
 #, python-format
 msgid "New in version %s"
 msgstr ""
 
-#: sphinx/locale/__init__.py:169
+#: sphinx/locale/__init__.py:173
 #, python-format
 msgid "Changed in version %s"
 msgstr ""
 
-#: sphinx/locale/__init__.py:170
+#: sphinx/locale/__init__.py:174
 #, python-format
 msgid "Deprecated since version %s"
 msgstr ""
 
-#: sphinx/locale/__init__.py:176
+#: sphinx/locale/__init__.py:180
 msgid "keyword"
 msgstr ""
 
-#: sphinx/locale/__init__.py:177
+#: sphinx/locale/__init__.py:181
 msgid "operator"
 msgstr ""
 
-#: sphinx/locale/__init__.py:178
+#: sphinx/locale/__init__.py:182
 msgid "object"
 msgstr ""
 
-#: sphinx/locale/__init__.py:180
+#: sphinx/locale/__init__.py:184
 msgid "statement"
 msgstr ""
 
-#: sphinx/locale/__init__.py:181
+#: sphinx/locale/__init__.py:185
 msgid "built-in function"
 msgstr ""
 
-#: sphinx/themes/agogo/layout.html:45 sphinx/themes/basic/globaltoc.html:10
-#: sphinx/themes/basic/localtoc.html:11
+#: sphinx/themes/agogo/layout.html:46 sphinx/themes/basic/globaltoc.html:10
+#: sphinx/themes/basic/localtoc.html:11 sphinx/themes/scrolls/layout.html:35
 msgid "Table Of Contents"
 msgstr ""
 
-#: sphinx/themes/agogo/layout.html:49 sphinx/themes/basic/layout.html:137
-#: sphinx/themes/basic/search.html:11 sphinx/themes/basic/search.html:20
+#: sphinx/themes/agogo/layout.html:51 sphinx/themes/basic/layout.html:138
+#: sphinx/themes/basic/search.html:11 sphinx/themes/basic/search.html:23
+#: sphinx/themes/basic/searchresults.html:10
 msgid "Search"
 msgstr ""
 
-#: sphinx/themes/agogo/layout.html:52 sphinx/themes/basic/searchbox.html:15
+#: sphinx/themes/agogo/layout.html:54 sphinx/themes/basic/searchbox.html:15
 msgid "Go"
 msgstr ""
 
-#: sphinx/themes/agogo/layout.html:57 sphinx/themes/basic/searchbox.html:20
-msgid "Enter search terms or a module, class or function name."
-msgstr ""
-
-#: sphinx/themes/agogo/layout.html:78 sphinx/themes/basic/sourcelink.html:14
+#: sphinx/themes/agogo/layout.html:81 sphinx/themes/basic/sourcelink.html:15
 msgid "Show Source"
 msgstr ""
 
 #: sphinx/themes/basic/defindex.html:11
 msgid "Overview"
+msgstr ""
+
+#: sphinx/themes/basic/defindex.html:15
+msgid "Welcome! This is"
+msgstr ""
+
+#: sphinx/themes/basic/defindex.html:16
+msgid "the documentation for"
+msgstr ""
+
+#: sphinx/themes/basic/defindex.html:17
+msgid "last updated"
 msgstr ""
 
 #: sphinx/themes/basic/defindex.html:20
@@ -573,15 +668,15 @@ msgstr ""
 msgid "all functions, classes, terms"
 msgstr ""
 
-#: sphinx/themes/basic/genindex-single.html:35
+#: sphinx/themes/basic/genindex-single.html:33
 #, python-format
 msgid "Index &ndash; %(key)s"
 msgstr ""
 
-#: sphinx/themes/basic/genindex-single.html:63
+#: sphinx/themes/basic/genindex-single.html:61
 #: sphinx/themes/basic/genindex-split.html:24
 #: sphinx/themes/basic/genindex-split.html:38
-#: sphinx/themes/basic/genindex.html:74
+#: sphinx/themes/basic/genindex.html:72
 msgid "Full index on one page"
 msgstr ""
 
@@ -597,38 +692,38 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: sphinx/themes/basic/layout.html:122
+#: sphinx/themes/basic/layout.html:123
 #, python-format
 msgid "Search within %(docstitle)s"
 msgstr ""
 
-#: sphinx/themes/basic/layout.html:131
+#: sphinx/themes/basic/layout.html:132
 msgid "About these documents"
 msgstr ""
 
-#: sphinx/themes/basic/layout.html:140
+#: sphinx/themes/basic/layout.html:141
 msgid "Copyright"
 msgstr ""
 
-#: sphinx/themes/basic/layout.html:189
+#: sphinx/themes/basic/layout.html:186
 #, python-format
-msgid "&copy; <a href=\"%(path)s\">Copyright</a> %(copyright)s."
+msgid "&#169; <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr ""
 
-#: sphinx/themes/basic/layout.html:191
+#: sphinx/themes/basic/layout.html:188
 #, python-format
-msgid "&copy; Copyright %(copyright)s."
+msgid "&#169; Copyright %(copyright)s."
 msgstr ""
 
-#: sphinx/themes/basic/layout.html:195
+#: sphinx/themes/basic/layout.html:192
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr ""
 
-#: sphinx/themes/basic/layout.html:198
+#: sphinx/themes/basic/layout.html:195
 #, python-format
 msgid ""
-"Created using <a href=\"http://sphinx.pocoo.org/\">Sphinx</a> "
+"Created using <a href=\"http://sphinx-doc.org/\">Sphinx</a> "
 "%(sphinx_version)s."
 msgstr ""
 
@@ -653,13 +748,13 @@ msgstr ""
 msgid "next chapter"
 msgstr ""
 
-#: sphinx/themes/basic/search.html:24
+#: sphinx/themes/basic/search.html:27
 msgid ""
 "Please activate JavaScript to enable the search\n"
 "    functionality."
 msgstr ""
 
-#: sphinx/themes/basic/search.html:29
+#: sphinx/themes/basic/search.html:32
 msgid ""
 "From here you can search these documents. Enter your search\n"
 "    words into the box below and click \"search\". Note that the search\n"
@@ -667,36 +762,39 @@ msgid ""
 "    containing fewer words won't appear in the result list."
 msgstr ""
 
-#: sphinx/themes/basic/search.html:36
+#: sphinx/themes/basic/search.html:39 sphinx/themes/basic/searchresults.html:17
 msgid "search"
 msgstr ""
 
-#: sphinx/themes/basic/search.html:40
-#: sphinx/themes/basic/static/searchtools.js_t:299
+#: sphinx/themes/basic/search.html:43 sphinx/themes/basic/searchresults.html:21
+#: sphinx/themes/basic/static/searchtools.js_t:287
 msgid "Search Results"
 msgstr ""
 
-#: sphinx/themes/basic/search.html:42
-msgid "Your search did not match any results."
+#: sphinx/themes/basic/search.html:45 sphinx/themes/basic/searchresults.html:23
+#: sphinx/themes/basic/static/searchtools.js_t:289
+msgid ""
+"Your search did not match any documents. Please make sure that all words "
+"are spelled correctly and that you've selected enough categories."
 msgstr ""
 
 #: sphinx/themes/basic/searchbox.html:12
 msgid "Quick search"
 msgstr ""
 
-#: sphinx/themes/basic/sourcelink.html:11
+#: sphinx/themes/basic/sourcelink.html:12
 msgid "This Page"
 msgstr ""
 
 #: sphinx/themes/basic/changes/frameset.html:5
 #: sphinx/themes/basic/changes/versionchanges.html:12
 #, python-format
-msgid "Changes in Version %(version)s &mdash; %(docstitle)s"
+msgid "Changes in Version %(version)s &#8212; %(docstitle)s"
 msgstr ""
 
 #: sphinx/themes/basic/changes/rstsource.html:5
 #, python-format
-msgid "%(filename)s &mdash; %(docstitle)s"
+msgid "%(filename)s &#8212; %(docstitle)s"
 msgstr ""
 
 #: sphinx/themes/basic/changes/versionchanges.html:17
@@ -716,70 +814,98 @@ msgstr ""
 msgid "Other changes"
 msgstr ""
 
-#: sphinx/themes/basic/static/doctools.js:154 sphinx/writers/html.py:504
-#: sphinx/writers/html.py:510
+#: sphinx/themes/basic/static/doctools.js_t:169 sphinx/writers/html.py:708
+#: sphinx/writers/html.py:713
 msgid "Permalink to this headline"
 msgstr ""
 
-#: sphinx/themes/basic/static/doctools.js:160 sphinx/writers/html.py:92
+#: sphinx/themes/basic/static/doctools.js_t:175 sphinx/writers/html.py:108
+#: sphinx/writers/html.py:117
 msgid "Permalink to this definition"
 msgstr ""
 
-#: sphinx/themes/basic/static/doctools.js:189
+#: sphinx/themes/basic/static/doctools.js_t:208
 msgid "Hide Search Matches"
 msgstr ""
 
-#: sphinx/themes/basic/static/searchtools.js_t:106
+#: sphinx/themes/basic/static/searchtools.js_t:121
 msgid "Searching"
 msgstr ""
 
-#: sphinx/themes/basic/static/searchtools.js_t:111
+#: sphinx/themes/basic/static/searchtools.js_t:126
 msgid "Preparing search..."
 msgstr ""
 
-#: sphinx/themes/basic/static/searchtools.js_t:301
-msgid "Your search did not match any documents. Please make sure that all words are spelled correctly and that you've selected enough categories."
-msgstr ""
-
-#: sphinx/themes/basic/static/searchtools.js_t:303
+#: sphinx/themes/basic/static/searchtools.js_t:291
+#, python-format
 msgid "Search finished, found %s page(s) matching the search query."
 msgstr ""
 
-#: sphinx/themes/basic/static/searchtools.js_t:343
+#: sphinx/themes/basic/static/searchtools.js_t:344
 msgid ", in "
 msgstr ""
 
-#: sphinx/themes/default/static/sidebar.js:69
+#: sphinx/themes/classic/static/sidebar.js_t:83
 msgid "Expand sidebar"
 msgstr ""
 
-#: sphinx/themes/default/static/sidebar.js:82
-#: sphinx/themes/default/static/sidebar.js:110
+#: sphinx/themes/classic/static/sidebar.js_t:96
+#: sphinx/themes/classic/static/sidebar.js_t:124
 msgid "Collapse sidebar"
 msgstr ""
 
-#: sphinx/themes/haiku/layout.html:26
+#: sphinx/themes/haiku/layout.html:24
 msgid "Contents"
 msgstr ""
 
-#: sphinx/writers/latex.py:177
+#: sphinx/writers/html.py:389
+msgid "Permalink to this code"
+msgstr ""
+
+#: sphinx/writers/html.py:393
+msgid "Permalink to this image"
+msgstr ""
+
+#: sphinx/writers/html.py:395
+msgid "Permalink to this toctree"
+msgstr ""
+
+#: sphinx/writers/html.py:717
+msgid "Permalink to this table"
+msgstr ""
+
+#: sphinx/writers/latex.py:380
 msgid "Release"
 msgstr ""
 
-#: sphinx/writers/latex.py:594 sphinx/writers/manpage.py:182
-#: sphinx/writers/texinfo.py:589
+#: sphinx/writers/latex.py:483
+msgid "page"
+msgstr ""
+
+#: sphinx/writers/latex.py:528
+#, python-format
+msgid "Unknown configure key: latex_elements[%r] is ignored."
+msgstr ""
+
+#: sphinx/writers/latex.py:1003 sphinx/writers/manpage.py:238
+#: sphinx/writers/texinfo.py:619
 msgid "Footnotes"
 msgstr ""
 
-#: sphinx/writers/latex.py:676
+#: sphinx/writers/latex.py:1112
 msgid "continued from previous page"
 msgstr ""
 
-#: sphinx/writers/latex.py:681
+#: sphinx/writers/latex.py:1118
 msgid "Continued on next page"
 msgstr ""
 
-#: sphinx/writers/text.py:437
+#: sphinx/writers/manpage.py:287 sphinx/writers/text.py:591
+#, python-format
+msgid "[image: %s]"
+msgstr ""
+
+#: sphinx/writers/manpage.py:288 sphinx/writers/text.py:592
 msgid "[image]"
 msgstr ""
 

--- a/resources/help/translations/templates/view_editor.pot
+++ b/resources/help/translations/templates/view_editor.pot
@@ -1,13 +1,13 @@
 # Messages from view_editor.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/resources/help/translations/templates/vsf_dialogs.pot
+++ b/resources/help/translations/templates/vsf_dialogs.pot
@@ -1,13 +1,13 @@
 # Messages from vsf_dialogs.txt
-# Copyright (C) 2002-2012, Jeremy Bowman
+# Copyright (C) 2002-2017, Jeremy Bowman
 # This file is distributed under the same license as the PortaBase package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PortaBase 2.1\n"
-"Report-Msgid-Bugs-To: https://sourceforge.net/p/portabase/bugs/\n"
+"Project-Id-Version: PortaBase\n"
+"Report-Msgid-Bugs-To: https://github.com/jmbowman/portabase/issues\n"
 "POT-Creation-Date: 2012-07-27 20:40-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"


### PR DESCRIPTION
* More changes to switch away from SourceForge URLs
* Updated copyright years
* Removed the specific PortaBase version from the templates (needing to update the current year is bad enough)
* Updated a few of the help file translation templates to match recent changes to the content (new command line options, no more image resolution limit, minor updates to row color preferences)
* Added the latest translation template for Sphinx