### PR TITLE
Prepare Maemo files for a new release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,9 @@
     * Fixed the spacing on the popup menu for the column statistics dialog's
       column listing.
     * Updated the help file translation templates
+    * Reverted a change in QQMenuHelper that broke compatibility with Qt 4.5
+      (still needed for the Maemo releases)
+    * Updated assorted Maemo packaging files for the upcoming 2.2 release
 
 2017-03-30  JMB  Update UI translations, fix them on Android, new help theme
 

--- a/packaging/maemo/debian/changelog
+++ b/packaging/maemo/debian/changelog
@@ -1,3 +1,9 @@
+portabase (2.2-1) unstable; urgency=low
+
+  * New upstream version
+
+ -- Jeremy Bowman <jmbowman@alum.mit.edu>  Sun, 02 Apr 2017 21:00:46 -0500
+
 portabase (2.1-2) unstable; urgency=low
 
   * Updated application icon data in control file

--- a/packaging/maemo/debian/control
+++ b/packaging/maemo/debian/control
@@ -12,8 +12,8 @@ Description: An easy-to-use personal database application
  PortaBase is a program for conveniently managing one-table database files.
  It can be used as a shopping list, password manager, media inventory,
  financial tracker, TODO list, address book, photo album, and more. It is
- available for many platforms, including Linux, Mac OS X, Windows, and Maemo.
- Features include:
+ available for many platforms, including Android, Linux, Mac OS X, Windows,
+ and Maemo. Features include:
  .
   * String, Integer, Decimal, Boolean, Note (multi-line text), Date, Time,
     Calculation, Sequence, Image, and Enum column types;
@@ -30,7 +30,7 @@ Description: An easy-to-use personal database application
   * optional data file encryption.
 XB-Maemo-Display-Name: PortaBase
 XB-Homepage: http://www.portabase.org
-XB-Bugtracker: https://sourceforge.net/p/portabase/bugs/
+XB-Bugtracker: https://github.com/jmbowman/portabase/issues
 XB-Maemo-Icon-26:
  iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ
  bWFnZVJlYWR5ccllPAAACm9JREFUeNrsWUtsXNUZ/ubOvfN+244f5OEEB8fQJgYkCgWKoaVERYWg

--- a/packaging/maemo/debian/copyright
+++ b/packaging/maemo/debian/copyright
@@ -3,7 +3,7 @@ Fri, Apr 18 15:25:01 -0500.
 
 Author: Jeremy Bowman <jmbowman@alum.mit.edu>
 
-Copyright 2002-2010 by Jeremy Bowman
+Copyright 2002-2017 by Jeremy Bowman
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/packaging/maemo/debian/install
+++ b/packaging/maemo/debian/install
@@ -11,6 +11,10 @@ src/resources/help/_build/fr/*.html opt/portabase/help/fr
 src/resources/help/_build/fr/*.inv opt/portabase/help/fr
 src/resources/help/_build/fr/*.js opt/portabase/help/fr
 src/resources/help/_build/fr/_sources/* opt/portabase/help/fr/_sources
+src/resources/help/_build/it/*.html usr/share/portabase/help/fr
+src/resources/help/_build/it/*.inv usr/share/portabase/help/fr
+src/resources/help/_build/it/*.js usr/share/portabase/help/fr
+src/resources/help/_build/it/_sources/* usr/share/portabase/help/fr/_sources
 src/resources/help/_build/ja/*.html opt/portabase/help/ja
 src/resources/help/_build/ja/*.inv opt/portabase/help/ja
 src/resources/help/_build/ja/*.js opt/portabase/help/ja

--- a/packaging/maemo/diablo_control
+++ b/packaging/maemo/diablo_control
@@ -12,8 +12,8 @@ Description: An easy-to-use personal database application
  PortaBase is a program for conveniently managing one-table database files.
  It can be used as a shopping list, password manager, media inventory,
  financial tracker, TODO list, address book, photo album, and more. It is
- available for many platforms, including Linux, Mac OS X, Windows, and Maemo.
- Features include:
+ available for many platforms, including Android, Linux, Mac OS X, Windows,
+ and Maemo. Features include:
  .
   * String, Integer, Decimal, Boolean, Note (multi-line text), Date, Time,
     Calculation, Sequence, Image, and Enum column types;
@@ -30,7 +30,7 @@ Description: An easy-to-use personal database application
   * optional data file encryption.
 XB-Maemo-Display-Name: PortaBase
 XB-Homepage: http://www.portabase.org
-XB-Bugtracker: https://sourceforge.net/p/portabase/bugs/
+XB-Bugtracker: https://github.com/jmbowman/portabase/issues
 XB-Maemo-Icon-26:
  iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAYAAACpSkzOAAAABmJLR0QA/wD/AP+gvaeTAAAACXBI
  WXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3AkJEBoIe+CKlgAABuxJREFUSMedVmtwlFcZft7zXfaS

--- a/packaging/maemo/diablo_install
+++ b/packaging/maemo/diablo_install
@@ -11,6 +11,10 @@ src/resources/help/_build/fr/*.html usr/share/portabase/help/fr
 src/resources/help/_build/fr/*.inv usr/share/portabase/help/fr
 src/resources/help/_build/fr/*.js usr/share/portabase/help/fr
 src/resources/help/_build/fr/_sources/* usr/share/portabase/help/fr/_sources
+src/resources/help/_build/it/*.html usr/share/portabase/help/fr
+src/resources/help/_build/it/*.inv usr/share/portabase/help/fr
+src/resources/help/_build/it/*.js usr/share/portabase/help/fr
+src/resources/help/_build/it/_sources/* usr/share/portabase/help/fr/_sources
 src/resources/help/_build/ja/*.html usr/share/portabase/help/ja
 src/resources/help/_build/ja/*.inv usr/share/portabase/help/ja
 src/resources/help/_build/ja/*.js usr/share/portabase/help/ja

--- a/src/qqutil/qqmenuhelper.cpp
+++ b/src/qqutil/qqmenuhelper.cpp
@@ -24,7 +24,7 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
-#include <QProcessEnvironment>
+#include <QProcess>
 #include <QRegExp>
 #include <QSettings>
 #include <QUrl>
@@ -443,10 +443,12 @@ void QQMenuHelper::setHelpLocation(const QString &urlTemplate,
  */
 void QQMenuHelper::showHelp()
 {
-    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    QStringList env = QProcess::systemEnvironment();
     QString var = QString("%1_HELP").arg(qApp->applicationName().toUpper());
-    QString helpDir = env.value(var);
-    if (!helpDir.isEmpty()) {
+    QString helpDir;
+    int index = env.indexOf(QRegExp(QString("%1=.*").arg(var)));
+    if (index != -1) {
+        QString helpDir = env[index];
         helpDir = helpDir.right(helpDir.length() - var.length() - 1);
     }
     else {


### PR DESCRIPTION
I miscalculated how early QProcessEnvironment was introduced, so I had to revert a recent change to QQMenuHelper to fix Maemo builds again.  Also updated assorted Maemo packaging files to prepare for the next release:

* Bumped the version number
* Switched more URLs away from SourceForge
* Added the Italian help files translation
* Updated copyright years
* Mentioned the existence of an Android port