### PR TITLE
Option to include enums in Any text column conditions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+2017-12-03  JMB  Option to include enums in "Any text column" conditions
+
+    There is now a checkbox in the "General" preferences tab to include
+    enums as well as string and note fields in "Any text column" filter
+    conditions.  The default behavior is as before (enums excluded).
+
 2017-04-06  JMB  More translation updates
 
     Updated assorted translation files, mainly due to a few text changes

--- a/resources/help/preferences.txt
+++ b/resources/help/preferences.txt
@@ -30,6 +30,9 @@ The "General" tab contains the following options:
 **Use small-screen settings on this device**
   When checked, PortaBase uses default values for certain settings (such as column width, rows per page, etc.) which are more appropriate for small displays.  This can usually be guessed based on the operating system in use, but some netbooks and MIDs running PC operating systems might be better off with the small-screen settings.
 
+**Include enums in "Any text column" conditions**
+  When checked, filter conditions using "Any text column" as the subject will also operate on Enum columns in addition to the usual Strings and Notes.
+
 **Auto-rotate to match device orientation** (Maemo Fremantle only)
   When checked, the application will automatically switch between landscape and portrait display, depending on the current orientation of the device.
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -133,6 +133,9 @@ c4_View Condition::filter(c4_View dbview)
                 if (type == STRING || type == NOTE) {
                     textCols.append(name);
                 }
+                if (type >= FIRST_ENUM && db->anyTextColumnIncludesEnums()) {
+                    textCols.append(name);
+                }
             }
             count = textCols.count();
         }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -206,7 +206,7 @@ QString Database::load()
 /**
  * Determine if the database file is encrypted or not.
  *
- @return True if the file is encrypted, false otherwise
+ * @return True if the file is encrypted, false otherwise
  */
 Crypto *Database::encryption()
 {
@@ -214,7 +214,7 @@ Crypto *Database::encryption()
 }
 
 /**
- * Reload the application settings for date and time formatting and screen
+ * Reload the application settings for "Any text column" conditions and screen
  * size.  Called when a file is first opened, and again whenever changes are
  * made in the Preferences dialog.
  */
@@ -226,7 +226,20 @@ void Database::updatePreferences()
 #else
     bool smallDefault = false;
 #endif
+    anyTextIncludesEnums = settings.value("General/AnyTextIncludesEnums", false).toBool();
     smallScreen = settings.value("General/SmallScreen", smallDefault).toBool();
+
+}
+
+/**
+ * Determine "any text column" conditions include enums in addition to string
+ * and note fields.
+ *
+ * @return True if enums are included, false otherwise
+ */
+bool Database::anyTextColumnIncludesEnums()
+{
+    return anyTextIncludesEnums;
 }
 
 /**

--- a/src/database.h
+++ b/src/database.h
@@ -113,6 +113,7 @@ public:
     void deleteFilterColumn(const QString &filterName, const QString &columnName);
     int getConditionCount(const QString &filterName);
     Condition *getCondition(const QString &filterName, int index);
+    bool anyTextColumnIncludesEnums();
 
     QStringList listEnums();
     QStringList listEnumOptions(int id);
@@ -175,6 +176,7 @@ private:
     void calculateAll(int colId, CalcNode *root, int decimals);
 
 private:
+    bool anyTextIncludesEnums; /**< True if currently including enums in "Any text column" conditions */
     bool smallScreen; /**< True if currently using column widths and rows per page for small-screen devices */
     c4_Storage *file; /**< The data file */
     c4_Storage *storage; /**< The data file if unencrypted, wrapped data otherwise */

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -110,6 +110,10 @@ void Preferences::addGeneralTab(QSettings *settings)
     smallScreen->setChecked(settings->value("SmallScreen", smallDefault).toBool());
     layout->addWidget(smallScreen);
 
+    anyTextIncludesEnums = new QCheckBox(tr("Include enums in \"Any text column\" conditions"));
+    anyTextIncludesEnums->setChecked(settings->value("AnyTextIncludesEnums", false).toBool());
+    layout->addWidget(anyTextIncludesEnums);
+
 #if defined(Q_WS_MAEMO_5)
     autoRotate = new QCheckBox(tr("Auto-rotate to match device orientation"),
                                generalTab);
@@ -442,6 +446,7 @@ QFont Preferences::applyChanges()
     settings.setValue("RowsPerPage", rowsPerPage->value());
 #endif
     settings.setValue("SmallScreen", smallScreen->isChecked());
+    settings.setValue("AnyTextIncludesEnums", anyTextIncludesEnums->isChecked());
     settings.endGroup();
 
 #if defined(Q_WS_MAEMO_5)

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -75,6 +75,7 @@ private:
     QCheckBox *autoRotate; /**< Option to auto-rotate with Fremantle device orientation */
     QQSpinBox *rowsPerPage; /**< Number of rows to display on each page of the data view */
     QCheckBox *smallScreen; /**< Option to use settings for PDA/phone-sized screens */
+    QCheckBox *anyTextIncludesEnums; /**< Option to include enum fields in "Any text column" conditions */
     QCheckBox *useAlternating; /**< Option to turn off alternating row colors on Fremantle*/
     QtColorPicker *evenButton; /**< Button to select the color of even rows */
     QtColorPicker *oddButton; /**< Button to select the color of odd rows */


### PR DESCRIPTION
Added a checkbox in the "General" preferences tab to include enums as well as string and note fields in "Any text column" filter conditions.  The default behavior is as before (enums excluded).