### PR TITLE
Calculation editor layout fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+2017-12-07  JMB  Calculation editor layout fixes
+
+    Fixed the layout on Android for the dialogs to define and edit calculation
+    columns.  Also fixed the refresh button on calculation fields in the row
+    viewer to be an appropriate width.
+
 2017-12-03  JMB  Option to include enums in "Any text column" conditions
 
     There is now a checkbox in the "General" preferences tab to include

--- a/src/calc/calcdateeditor.cpp
+++ b/src/calc/calcdateeditor.cpp
@@ -66,6 +66,9 @@ CalcDateEditor::CalcDateEditor(const QStringList &colNames, int *colTypes, QWidg
         colButton->setEnabled(false);
     }
 
+#if defined(Q_OS_ANDROID)
+    vbox->addStretch(1);
+#endif
     finishLayout();
 }
 

--- a/src/calc/calcnodeeditor.cpp
+++ b/src/calc/calcnodeeditor.cpp
@@ -39,6 +39,7 @@ CalcNodeEditor::CalcNodeEditor(const QStringList &colNames, int *colTypes, bool 
 {
     group = new QButtonGroup(this);
     QGridLayout *grid = Factory::gridLayout(vbox);
+    vbox->setStretchFactor(grid, 1);
     QRadioButton *colButton = new QRadioButton(tr("Column"), this);
     group->addButton(colButton, 0);
     grid->addWidget(colButton, 0, 0);

--- a/src/calc/calctimeeditor.cpp
+++ b/src/calc/calctimeeditor.cpp
@@ -69,6 +69,9 @@ CalcTimeEditor::CalcTimeEditor(Database *dbase, const QStringList &colNames, int
         colButton->setEnabled(false);
     }
 
+#if defined(Q_OS_ANDROID)
+    vbox->addStretch(1);
+#endif
     finishLayout(parent->width() / 2);
 }
 

--- a/src/calc/calcwidget.cpp
+++ b/src/calc/calcwidget.cpp
@@ -39,6 +39,7 @@ CalcWidget::CalcWidget(Database *dbase, const QString &calcName, const QStringLi
     QHBoxLayout *layout = Factory::hBoxLayout(this, true);
     display = new QLabel(this);
     layout->addWidget(display);
+    layout->setStretchFactor(display, 1);
     QAbstractButton *button = Factory::button(this);
     button->setIcon(Factory::icon("refresh"));
     button->setToolTip(tr("Update calculated value"));


### PR DESCRIPTION
Fixed the layout on Android for the dialogs to define and edit calculation columns.  Also fixed the refresh button on calculation fields in the row viewer to be an appropriate width.