### PR TITLE
Fix modification tracking in column statistics dialog

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+2017-12-13  JMB  Fix modification tracking in column statistics dialog
+
+    There was a minor bug in the column statistics dialog where it would
+    consider there to have been a change needing to be saved anytime the
+    "OK" button was clicked, even if no column widths were actually
+    modified.  Fixed to only mark the file as needing to be saved if such
+    a width modification is actually made.
+
 2017-12-12  JMB  Incremental search on Android
 
     Added an action bar item to display the software keyboard so the
@@ -28,6 +36,8 @@
     it to be signed on OS X 10.11.5 or above.  This should fix the
     "unidentified developer" warnings that people have started seeing with
     the previous PortaBase release on newer OS versions.
+
+2017-04-02  ############# PortaBase 2.2 (Android only) #############
 
 2017-04-02  JMB  Release preparation and assorted bugfixes
 

--- a/src/columninfo.cpp
+++ b/src/columninfo.cpp
@@ -60,7 +60,6 @@ ColumnInfoDialog::ColumnInfoDialog(QWidget *parent)
 bool ColumnInfoDialog::launch(View *currentView, const QString &colName)
 {
     view = currentView;
-    edited = false;
     columns->clear();
     columns->addItems(view->getColNames());
     int i;
@@ -75,6 +74,7 @@ bool ColumnInfoDialog::launch(View *currentView, const QString &colName)
         columns->setCurrentIndex(i);
         colWidth->setValue(view->getColWidth(i));
     }
+    edited = false;
     if (exec()) {
         if (edited) {
             for (i = 0; i < columns->count(); i++) {
@@ -107,7 +107,9 @@ void ColumnInfoDialog::columnSelected(int index)
     display->setHtml(content.join(""));
     QVariant width = columns->itemData(index);
     if (width.isValid()) {
+        bool oldEdited = edited;
         colWidth->setValue(width.toInt());
+        edited = oldEdited;
     }
 }
 


### PR DESCRIPTION
There was a minor bug in the column statistics dialog where it would consider there to have been a change needing to be saved anytime the "OK" button was clicked, even if no column widths were actually modified.  Fixed to only mark the file as needing to be saved if such a width modification is actually made.