### PR TITLE
Fix bug in Mac toolbar customization

### DIFF
--- a/portabase.pro
+++ b/portabase.pro
@@ -216,7 +216,7 @@ android-g++ {
 macx {
     CONFIG             += c++11 release x86_64
     QMAKE_CXXFLAGS     += -stdlib=libc++ -std=c++11
-    QMAKE_MAC_SDK       = macosx10.12
+    QMAKE_MAC_SDK       = macosx10.15
     QT                 += macextras
     INCLUDEPATH        += /usr/local/include
     LIBS               += -L/usr/local/lib -framework Foundation

--- a/src/qqutil/qqmenuhelper.cpp
+++ b/src/qqutil/qqmenuhelper.cpp
@@ -312,6 +312,7 @@ void QQMenuHelper::loadSettings(QSettings *settings)
  * <li>Updates the list of most recently opened files.</li>
  * <li>Updates the last directory where the application either opened or saved
  * a document file</li>
+ * <li>On macOS, saves the current toolbar configuration</li>
  * </ul>
  * @param settings The QSettings object to be updated.
  */

--- a/src/qqutil/qqtoolbar.cpp
+++ b/src/qqutil/qqtoolbar.cpp
@@ -145,7 +145,7 @@ void QQToolBar::add(QAction *action)
 
 /**
  * Load saved toolbar configuration options.  Primarily called by
- * QQMenuHelper, and currently only does anything on Mac OS X (where it
+ * QQMenuHelper, and currently only does anything on macOS (where it
  * handles icon size, icon and/or text preference, and the set of buttons
  * currently shown).
  *
@@ -188,6 +188,9 @@ void QQToolBar::loadSettings(QSettings *settings)
 void QQToolBar::saveSettings(QSettings *settings)
 {
 #if defined(Q_OS_MAC)
+    if (QQToolBar::currentToolBar != this) {
+        return;
+    }
     settings->beginGroup(identifier);
     settings->setValue("displayMode", QQMacToolBarUtils::displayMode(toolBar));
     settings->setValue("sizeMode", QQMacToolBarUtils::sizeMode(toolBar));
@@ -222,6 +225,8 @@ void QQToolBar::show()
     }
 #if defined(Q_OS_MAC)
     if (QQToolBar::currentToolBar) {
+        QSettings settings;
+        QQToolBar::currentToolBar->saveSettings(&settings);
         QQMacToolBarUtils::copyState(QQToolBar::currentToolBar->toolBar, toolBar);
     }
     toolBar->attachToWindow(mainWindow->window()->windowHandle());


### PR DESCRIPTION
There was a bug in the saving of Mac toolbar content customization where the content of the data viewer toolbar would be lost when customizing the file selector toolbar in a session where the data viewer wasn't opened.  Fixed the settings persistence to only save changes to the toolbar which is currently displayed.

Also updated the Mac SDK to the version required for Qt 5.15, which I plan to use for the next release.  I just tested that PortaBase successfully builds and runs with it, although I'll want to fix a cosmetic issue or two before releasing.