### PR TITLE
Correctly handle row colors with alpha

### DIFF
--- a/packaging/mac/build.sh
+++ b/packaging/mac/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# (c) 2010-2016 by Jeremy Bowman <jmbowman@alum.mit.edu>
+# (c) 2010-2016,2020 by Jeremy Bowman <jmbowman@alum.mit.edu>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@ rm -rf build/$DIRNAME
 rm -rf resources/help/_build/_static # in case created for Maemo
 
 # compile and make the application bundle
-qmake -spec macx-llvm portabase.pro
+qmake -spec macx-clang portabase.pro
 if [ "$1" == "--sign" ]; then
     SIGN=Yes
     shift 1

--- a/portabase.pro
+++ b/portabase.pro
@@ -216,7 +216,6 @@ android-g++ {
 macx {
     CONFIG             += c++11 release x86_64
     QMAKE_CXXFLAGS     += -stdlib=libc++ -std=c++11
-    QMAKE_MAC_SDK       = macosx10.15
     QT                 += macextras
     INCLUDEPATH        += /usr/local/include
     LIBS               += -L/usr/local/lib -framework Foundation

--- a/src/color_picker/qtcolorpicker.cpp
+++ b/src/color_picker/qtcolorpicker.cpp
@@ -3,7 +3,7 @@
 ** This file is part of a Qt Solutions component.
 ** 
 ** Copyright (c) 2009 Nokia Corporation and/or its subsidiary(-ies).
-** Copyright (c) 2016-2017 by Jeremy Bowman <jmbowman@alum.mit.edu>
+** Copyright (c) 2016-2017,2020 by Jeremy Bowman <jmbowman@alum.mit.edu>
 ** 
 ** Contact:  Qt Software Information (qt-info@nokia.com)
 ** 
@@ -520,10 +520,8 @@ void ColorPickerPopup::insertColor(const QColor &col, const QString &text, int i
     if (lastSelectedItem) {
         lastSelectedItem->setSelected(false);
     }
-    else {
-        item->setSelected(true);
-        lastSel = col;
-    }
+    item->setSelected(true);
+    lastSel = col;
     item->setFocus();
 
     connect(item, SIGNAL(selected()), SLOT(updateSelected()));
@@ -800,21 +798,23 @@ void ColorPickerPopup::regenerateGrid()
 */
 void ColorPickerPopup::getColorFromDialog()
 {
+#if QT_VERSION >= 0x050000
+    QColorDialog colorDialog(parentWidget());
+    colorDialog.setOption(QColorDialog::ShowAlphaChannel);
+    colorDialog.setCurrentColor(lastSel);
 #if defined(Q_OS_ANDROID)
     // This is still almost unusable, but at least it fits on the screen
-    QColorDialog colorDialog(lastSel, parentWidget());
     colorDialog.showMaximized();
+#endif
     if (!colorDialog.exec()) {
         return;
     }
     QColor col = colorDialog.currentColor();
-#elif QT_VERSION >= 0x050000
-    QColor col = QColorDialog::getColor(lastSel, parentWidget());
 #else
     bool ok;
     QRgb rgb = QColorDialog::getRgba(lastSel.rgba(), &ok, parentWidget());
     if (!ok)
-	return;
+       return;
 
     QColor col = QColor::fromRgba(rgb);
 #endif

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -1,7 +1,7 @@
 /*
  * factory.cpp
  *
- * (c) 2008-2012,2016-2017 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2008-2012,2016-2017,2020 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,17 +41,25 @@ void Factory::updatePreferences(QSettings *settings)
     settings->beginGroup("Colors");
     useAlternatingRowColors = settings->value("UseAlternating",
                                               true).toBool();
-    QString defaultBase = qApp->palette("QAbstractItemView").color(QPalette::Base).name();
-    QString color = settings->value("EvenRows", defaultBase).toString();
-    evenRowColor = QColor(color);
+    if (settings->contains("EvenRows")) {
+        evenRowColor = QColor(settings->value("EvenRows").toString());
+        evenRowColor.setAlpha(settings->value("EvenRowsAlpha", 255).toInt());
+    }
+    else {
+        evenRowColor = qApp->palette("QAbstractItemView").color(QPalette::Base);
+    }
+    if (settings->contains("OddRows")) {
+        oddRowColor = QColor(settings->value("OddRows").toString());
+        oddRowColor.setAlpha(settings->value("OddRowsAlpha", 255).toInt());
+    }
+    else {
 #if defined(Q_OS_ANDROID)
-    // The theme default alternate color is way too close to white
-    QString defaultAlternateBase("lightblue");
+        // The theme default alternate color is way too close to white
+        oddRowColor = defaultAlternateBase("lightblue");
 #else
-    QString defaultAlternateBase = qApp->palette("QAbstractItemView").color(QPalette::AlternateBase).name();
+        oddRowColor = qApp->palette("QAbstractItemView").color(QPalette::AlternateBase);
 #endif
-    color = settings->value("OddRows", defaultAlternateBase).toString();
-    oddRowColor = QColor(color);
+    }
     settings->endGroup();
 }
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -1,7 +1,7 @@
 /*
  * preferences.cpp
  *
- * (c) 2002-2004,2009-2012,2016-2017 by Jeremy Bowman <jmbowman@alum.mit.edu>
+ * (c) 2002-2004,2009-2012,2016-2017,2020 by Jeremy Bowman <jmbowman@alum.mit.edu>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -466,11 +466,15 @@ QFont Preferences::applyChanges()
     if (evenColor == defaultEven && oddColor == defaultOdd) {
         // Don't save the system defaults, match any changes made to them later
         settings.remove("EvenRows");
+        settings.remove("EvenRowsAlpha");
         settings.remove("OddRows");
+        settings.remove("OddRowsAlpha");
     }
     else {
         settings.setValue("EvenRows", evenColor.name());
+        settings.setValue("EvenRowsAlpha", evenColor.alpha());
         settings.setValue("OddRows", oddColor.name());
+        settings.setValue("OddRowsAlpha", oddColor.alpha());
     }
     settings.endGroup();
 #endif


### PR DESCRIPTION
* Added support for using row colors with an alpha channel, and correctly handle system default colors that use one.  (The default alternate row color in macOS dark mode uses white with 5% opacity.)
* Fixed the color dialog to consistently start with the currently selected color.
* Fixed macOS builds with recent Qt and Xcode versions.