### PR TITLE
Fix some colors in dark mode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,19 @@
+2020-08-04  JMB  Fixed color bugs in dark mode
+
+    Fixed some problems with the row viewer dialog and calculator
+    dialog which made parts of them difficult or impossible to read
+    under certain system themes (like macOS dark mode).
+
+2020-08-02  JMB  Updated Android packaging
+
+    Added support for building PortaBase for Android with Qt 5.15.0, and
+    documented how to do it.
+
+2020-06-08  JMB  Updated Windows packaging
+
+    Updated the Windows build scripts to work with recent versions of
+    Windows, Qt, Inno Setup, and Python.
+
 2020-06-06  JMB  More Debian package updates
 
     Fixed all issues reported by lintian for the generated package.

--- a/packaging/mac/build_metakit.sh
+++ b/packaging/mac/build_metakit.sh
@@ -18,5 +18,6 @@ else
 fi
 cd metakit/builds
 ../unix/configure --enable-threads --disable-shared
+make clean
 make
 sudo make install

--- a/src/calculator.cpp
+++ b/src/calculator.cpp
@@ -48,6 +48,7 @@ Calculator::Calculator(QWidget* parent)
     display->setAutoFillBackground(true);
     QPalette displayPalette(display->palette());
     displayPalette.setColor(QPalette::Window, Qt::white);
+    displayPalette.setColor(QPalette::WindowText, Qt::black);
     display->setPalette(displayPalette);
 #endif
 #if defined(Q_OS_ANDROID)

--- a/src/rowviewer.h
+++ b/src/rowviewer.h
@@ -56,6 +56,7 @@ private slots:
     void viewChanged(int index);
 
 private:
+    QColor alphaBlend(QColor base, QColor foreground);
     void updateContent();
     QString prepareString(const QString &content);
 


### PR DESCRIPTION
Fixed a few problems that manifested under certain themes such as macOS dark mode:

* The calculator dialog display used white text on a white background, making it unreadable.  It's now black on white regardless of theme.
* Half of the lines in the row viewer dialog had the wrong background color, they now match the other PortaBase widgets.
* Some of the checkbox icons in the row viewer dialog were black on dark and practically impossible to see.  They're now displayed just like regular checkbox widgets in the current theme.

Also made a small fix that makes it easier to switch between compiling Metakit for macOS or Android without running into problems.