### PR TITLE
Checkbox and calculation result display tweaks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+2020-08-31  JMB  Checkbox and calculation result display tweaks
+
+    Made an improvement to the recent row viewer changes for dark
+    mode support to show checkboxes with an appropriate size on
+    Android.  Also fixed the calculated field display in the row
+    editor to properly localize the value.
+
 2020-08-17  JMB  More Android build updates
 
     Got the Android version of PortaBase built by Qt 5.15.0 working.

--- a/src/calc/calcwidget.cpp
+++ b/src/calc/calcwidget.cpp
@@ -56,7 +56,7 @@ CalcWidget::CalcWidget(Database *dbase, const QString &calcName, const QStringLi
  */
 QString CalcWidget::getValue()
 {
-    return display->text();
+    return Formatting::fromLocalDouble(display->text());
 }
 
 /**
@@ -66,7 +66,7 @@ QString CalcWidget::getValue()
  */
 void CalcWidget::setValue(const QString &value)
 {
-    display->setText(value);
+    display->setText(Formatting::toLocalDouble(value));
 }
 
 /**

--- a/src/rowviewer.cpp
+++ b/src/rowviewer.cpp
@@ -109,27 +109,30 @@ RowViewer::RowViewer(Database *dbase, ViewDisplay *parent)
     hd->page()->setNetworkAccessManager(manager);
 #else
     // Make the boolean value images available in case we need them
+    int cbHeight = hd->fontMetrics().boundingRect("9").height();
     QCheckBox evenCheckBox;
+    evenCheckBox.resize(cbHeight * 2, cbHeight);
     QPalette evenPalette = evenCheckBox.palette();
     evenPalette.setColor(QPalette::Window, Factory::evenRowColor);
     evenCheckBox.setPalette(evenPalette);
     evenCheckBox.setChecked(true);
-    QPixmap checked_even(evenCheckBox.sizeHint());
+    QPixmap checked_even(evenCheckBox.size());
     evenCheckBox.render(&checked_even);
     evenCheckBox.setChecked(false);
-    QPixmap unchecked_even(evenCheckBox.sizeHint());
+    QPixmap unchecked_even(evenCheckBox.size());
     evenCheckBox.render(&unchecked_even);
 
     QColor altColor = alphaBlend(Factory::evenRowColor, Factory::oddRowColor);
     QCheckBox oddCheckBox;
+    oddCheckBox.resize(cbHeight * 2, cbHeight);
     QPalette oddPalette = oddCheckBox.palette();
     oddPalette.setColor(QPalette::Window, altColor);
     oddCheckBox.setPalette(oddPalette);
     oddCheckBox.setChecked(true);
-    QPixmap checked_odd(oddCheckBox.sizeHint());
+    QPixmap checked_odd(oddCheckBox.size());
     oddCheckBox.render(&checked_odd);
     oddCheckBox.setChecked(false);
-    QPixmap unchecked_odd(oddCheckBox.sizeHint());
+    QPixmap unchecked_odd(oddCheckBox.size());
     oddCheckBox.render(&unchecked_odd);
 
 #if !defined(Q_OS_ANDROID)


### PR DESCRIPTION
Made an improvement to the recent row viewer changes for dark mode support to show checkboxes with an appropriate size on Android.  Also fixed the calculated field display in the row editor to properly localize the value.