### PR TITLE
Fixed time field display, updated macOS code signing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+2020-09-20  JMB  Fixed time field display, updated macOS code signing
+
+    Fixed an 11-year-old bug that prevented time fields from being
+    saved or displayed correctly (caused by the Qt 4 port).  Also
+    updated the list of files that need to be signed for macOS
+    packages.
+
 2020-08-31  JMB  Checkbox and calculation result display tweaks
 
     Made an improvement to the recent row viewer changes for dark

--- a/packaging/mac/build.sh
+++ b/packaging/mac/build.sh
@@ -90,16 +90,21 @@ cd build
 # sign the binaries if the "--sign" parameter was passed in
 if [ "$SIGN" == "Yes" ]; then
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/Frameworks/QtCore.framework/Versions/5/QtCore
+    codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/Frameworks/QtDBus.framework/Versions/5/QtDBus
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/Frameworks/QtGui.framework/Versions/5/QtGui
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/Frameworks/QtMacExtras.framework/Versions/5/QtMacExtras
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport
+    codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/Frameworks/QtSvg.framework/Versions/5/QtSvg
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/Frameworks/QtWidgets.framework/Versions/5/QtWidgets
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/Frameworks/QtXml.framework/Versions/5/QtXml
+    codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/PlugIns/iconengines/libqsvgicon.dylib
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/PlugIns/imageformats/libqgif.dylib
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/PlugIns/imageformats/libqico.dylib
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/PlugIns/imageformats/libqjpeg.dylib
+    codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/PlugIns/imageformats/libqmacheif.dylib
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/PlugIns/platforms/libqcocoa.dylib
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/PlugIns/printsupport/libcocoaprintersupport.dylib
+    codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app/Contents/PlugIns/styles/libqmacstyle.dylib
     codesign -s "Developer ID Application: Jeremy Bowman" PortaBase.app
 fi
 

--- a/src/formatting.cpp
+++ b/src/formatting.cpp
@@ -227,7 +227,7 @@ QString Formatting::timeToString(int time)
     if (time == -1) {
         return "";
     }
-    QTime midnight;
+    QTime midnight(0, 0);
     QTime timeObj = midnight.addSecs(time);
     return timeObj.toString(timeFormat);
 }
@@ -305,7 +305,7 @@ QString Formatting::parseTimeString(const QString &value, bool *ok)
         *ok = false;
         return value;
     }
-    QTime midnight;
+    QTime midnight(0, 0);
     int totalSeconds = midnight.secsTo(time);
     *ok = true;
     return QString::number(totalSeconds);


### PR DESCRIPTION
I used a time field for the first time in ages and noticed that all values displayed as blank; a change in the QTime API for Qt 4 had broken this almost 11 years ago and nobody seemed to notice.  It's fixed now, in case anyone actually tries to use it.

I also updated the script for signing macOS releases to account for new files appearing in the distribution.  I think everything is ready for a PortaBase 2.3 release now, I just need to find time to build and upload the packages.